### PR TITLE
Unlike handling addition and events improvements

### DIFF
--- a/x/magpie/internal/keeper/handler.go
+++ b/x/magpie/internal/keeper/handler.go
@@ -33,15 +33,6 @@ func handleMsgCreateSession(ctx sdk.Context, keeper Keeper, msg types.MsgCreateS
 	// if yes, then continue and emit event
 	// else return error
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-			sdk.NewAttribute(sdk.AttributeKeyAction, types.ActionCreationSession),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Owner.String()),
-		),
-	)
-
 	// Get the public key used to sign the message
 	pkBytes, _ := base64.StdEncoding.DecodeString(msg.PubKey)
 	var pkBytes33 = [33]byte{}
@@ -92,17 +83,17 @@ func handleMsgCreateSession(ctx sdk.Context, keeper Keeper, msg types.MsgCreateS
 		return err.Result()
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			types.EventTypeCreateSession,
-			sdk.NewAttribute(types.AttributeKeySessionID, session.SessionID.String()),
-			sdk.NewAttribute(types.AttributeKeyNamespace, session.Namespace),
-			sdk.NewAttribute(types.AttributeKeyExternalOwner, session.ExternalOwner),
-			sdk.NewAttribute(types.AttributeKeyExpiry, strconv.FormatInt(session.Expiry, 10)),
-		),
+	createSessionEvent := sdk.NewEvent(
+		types.EventTypeCreateSession,
+		sdk.NewAttribute(types.AttributeKeySessionID, session.SessionID.String()),
+		sdk.NewAttribute(types.AttributeKeyNamespace, session.Namespace),
+		sdk.NewAttribute(types.AttributeKeyExternalOwner, session.ExternalOwner),
+		sdk.NewAttribute(types.AttributeKeyExpiry, strconv.FormatInt(session.Expiry, 10)),
 	)
+	ctx.EventManager().EmitEvent(createSessionEvent)
 
 	return sdk.Result{
-		Events: ctx.EventManager().Events(),
+		Data:   types.ModuleCdc.MustMarshalBinaryLengthPrefixed(session.SessionID),
+		Events: sdk.Events{createSessionEvent},
 	}
 }

--- a/x/magpie/internal/keeper/handler_test.go
+++ b/x/magpie/internal/keeper/handler_test.go
@@ -58,14 +58,6 @@ func Test_handleMsgCreateSession(t *testing.T) {
 			handler := keeper.NewHandler(k)
 			res := handler(ctx, test.msg)
 
-			firstEvent := sdk.NewEvent(
-				sdk.EventTypeMessage,
-				sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-				sdk.NewAttribute(sdk.AttributeKeyAction, types.ActionCreationSession),
-				sdk.NewAttribute(sdk.AttributeKeySender, test.msg.Owner.String()),
-			)
-			assert.Contains(t, ctx.EventManager().Events(), firstEvent)
-
 			if len(test.error) == 0 {
 
 				// Check the response
@@ -98,11 +90,11 @@ func Test_handleMsgCreateSession(t *testing.T) {
 					sdk.NewAttribute(types.AttributeKeyExpiry, strconv.FormatInt(session.Expiry, 10)),
 				)
 
-				assert.Contains(t, res.Events, firstEvent)
 				assert.Contains(t, res.Events, creationEvent)
 			} else {
 				assert.False(t, res.IsOK())
 				assert.Contains(t, res.Log, test.error)
+				assert.Empty(t, res.Events)
 			}
 		})
 	}

--- a/x/posts/client/rest/rest.go
+++ b/x/posts/client/rest/rest.go
@@ -19,6 +19,7 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc("/posts", createPostHandler(cliCtx)).Methods("POST")
 	r.HandleFunc("/posts/{postID}", getPostHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc("/posts/likes", likePostHandler(cliCtx)).Methods("POST")
+	r.HandleFunc("/posts/likes", unlikePostHandler(cliCtx)).Methods("DELETE")
 }
 
 // --------------------------------------------------------------------------------------
@@ -102,6 +103,48 @@ func likePostHandler(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		msg := types.NewMsgLikePost(postID, addr)
+		err = msg.ValidateBasic()
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		utils.WriteGenerateStdTxResponse(w, cliCtx, baseReq, []sdk.Msg{msg})
+	}
+}
+
+type removeLikeReq struct {
+	BaseReq rest.BaseReq `json:"base_req"`
+	PostID  string       `json:"post_id"`
+}
+
+func unlikePostHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req removeLikeReq
+		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &req) {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse request")
+			return
+		}
+
+		baseReq := req.BaseReq.Sanitize()
+		if !baseReq.ValidateBasic(w) {
+			return
+		}
+
+		addr, err := sdk.AccAddressFromBech32(req.BaseReq.From)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// create the message
+		postID, err := types.ParsePostID(req.PostID)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		msg := types.NewMsgUnlikePost(postID, addr)
 		err = msg.ValidateBasic()
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/x/posts/internal/keeper/handler_test.go
+++ b/x/posts/internal/keeper/handler_test.go
@@ -86,20 +86,14 @@ func Test_handleMsgCreatePost(t *testing.T) {
 				assert.Equal(t, k.Cdc.MustMarshalBinaryLengthPrefixed(test.expPost.PostID), res.Data)
 
 				// Check the events
-				msgEvent := sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyAction, types.ActionCreatePost),
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-					sdk.NewAttribute(sdk.AttributeKeySender, test.msg.Creator.String()),
-				)
 				creationEvent := sdk.NewEvent(
-					types.EventTypeCreatePost,
+					types.EventTypePostCreated,
 					sdk.NewAttribute(types.AttributeKeyPostID, test.expPost.PostID.String()),
 					sdk.NewAttribute(types.AttributeKeyPostParentID, test.expPost.ParentID.String()),
 					sdk.NewAttribute(types.AttributeKeyCreationTime, test.expPost.Created.String()),
 					sdk.NewAttribute(types.AttributeKeyPostOwner, test.expPost.Owner.String()),
 				)
-				assert.Contains(t, ctx.EventManager().Events(), msgEvent)
+				assert.Len(t, ctx.EventManager().Events(), 1)
 				assert.Contains(t, ctx.EventManager().Events(), creationEvent)
 			}
 		})
@@ -179,14 +173,7 @@ func Test_handleMSgEditPost_invalid_requests(t *testing.T) {
 			assert.Empty(t, res.Events, 0)
 
 			// Check the events
-			assert.Len(t, ctx.EventManager().Events(), 1)
-			expectedEvent := sdk.NewEvent(
-				sdk.EventTypeMessage,
-				sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-				sdk.NewAttribute(sdk.AttributeKeyAction, types.ActionEditPost),
-				sdk.NewAttribute(sdk.AttributeKeySender, test.msg.Editor.String()),
-			)
-			assert.Contains(t, ctx.EventManager().Events(), expectedEvent)
+			assert.Empty(t, ctx.EventManager().Events())
 		})
 	}
 }
@@ -210,11 +197,11 @@ func Test_handleMsgEditPost_valid_request(t *testing.T) {
 
 	// Check the events
 	editEvent := sdk.NewEvent(
-		types.EventTypeEditPost,
+		types.EventTypePostEdited,
 		sdk.NewAttribute(types.AttributeKeyPostID, testPost.PostID.String()),
 		sdk.NewAttribute(types.AttributeKeyPostEditTime, strconv.FormatInt(ctx.BlockHeight(), 10)),
 	)
-	assert.Len(t, ctx.EventManager().Events(), 2)
+	assert.Len(t, ctx.EventManager().Events(), 1)
 	assert.Equal(t, ctx.EventManager().Events(), res.Events)
 	assert.Contains(t, ctx.EventManager().Events(), editEvent)
 
@@ -291,14 +278,7 @@ func Test_handleMsgLikePost_invalid_requests(t *testing.T) {
 			assert.Contains(t, res.Log, test.error)
 
 			// Events
-			assert.Len(t, ctx.EventManager().Events(), 1)
-			expectedEvent := sdk.NewEvent(
-				sdk.EventTypeMessage,
-				sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
-				sdk.NewAttribute(sdk.AttributeKeyAction, types.ActionLikePost),
-				sdk.NewAttribute(sdk.AttributeKeySender, test.msg.Liker.String()),
-			)
-			assert.Contains(t, ctx.EventManager().Events(), expectedEvent)
+			assert.Empty(t, ctx.EventManager().Events())
 		})
 	}
 }
@@ -327,11 +307,11 @@ func Test_handleMsgLikePost_valid_request(t *testing.T) {
 
 	// Check the events
 	creationEvent := sdk.NewEvent(
-		types.EventTypeLikePost,
+		types.EventTypePostLiked,
 		sdk.NewAttribute(types.AttributeKeyPostID, msg.PostID.String()),
 		sdk.NewAttribute(types.AttributeKeyLikeOwner, msg.Liker.String()),
 	)
-	assert.Len(t, ctx.EventManager().Events(), 2)
+	assert.Len(t, ctx.EventManager().Events(), 1)
 	assert.Equal(t, ctx.EventManager().Events(), res.Events)
 	assert.Contains(t, ctx.EventManager().Events(), creationEvent)
 

--- a/x/posts/internal/keeper/handler_test.go
+++ b/x/posts/internal/keeper/handler_test.go
@@ -315,7 +315,7 @@ func Test_handleMsgLikePost_valid_request(t *testing.T) {
 	assert.Equal(t, ctx.EventManager().Events(), res.Events)
 	assert.Contains(t, ctx.EventManager().Events(), creationEvent)
 
-	// Check that the post has a new like
+	// Check that the post has a new liker
 	expectedPost := types.Post{
 		PostID:     testPost.PostID,
 		ParentID:   testPost.ParentID,
@@ -329,7 +329,7 @@ func Test_handleMsgLikePost_valid_request(t *testing.T) {
 	k.Cdc.MustUnmarshalBinaryBare(store.Get([]byte(types.PostStorePrefix+testPost.PostID.String())), &storedPost)
 	assert.Equal(t, expectedPost, storedPost)
 
-	// Check the stored like
+	// Check the stored liker
 	expectedLikes := types.Likes{types.NewLike(ctx.BlockHeight(), msg.Liker)}
 
 	var storedLikes types.Likes

--- a/x/posts/internal/keeper/post_response_test.go
+++ b/x/posts/internal/keeper/post_response_test.go
@@ -20,16 +20,13 @@ func TestPostQueryResponse_MarshalJSON(t *testing.T) {
 		types.NewLike(11, liker),
 		types.NewLike(12, otherLiker),
 	}
-	children := types.Posts{
-		types.NewPost(types.PostID(98), types.PostID(10), "First comment!", true, "", 10, liker),
-		types.NewPost(types.PostID(100), types.PostID(11), "Second :(", true, "", 10, otherLiker),
-	}
+	children := types.PostIDs{types.PostID(98), types.PostID(100)}
 
 	response := keeper.NewPostResponse(post, likes, children)
 	jsonData, err := json.Marshal(&response)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"id":"10","parent_id":"0","message":"Post","created":"10","last_edited":"0","allows_comments":true,"external_reference":"","owner":"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47","likes":[{"created":"11","owner":"cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4"},{"created":"12","owner":"cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae"}],"children":[{"id":"98","parent_id":"10","message":"First comment!","created":"10","last_edited":"0","allows_comments":true,"external_reference":"","owner":"cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4"},{"id":"100","parent_id":"11","message":"Second :(","created":"10","last_edited":"0","allows_comments":true,"external_reference":"","owner":"cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae"}]}`,
+		`{"id":"10","parent_id":"0","message":"Post","created":"10","last_edited":"0","allows_comments":true,"external_reference":"","owner":"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47","likes":[{"created":"11","owner":"cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4"},{"created":"12","owner":"cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae"}],"children":["98","100"]}`,
 		string(jsonData),
 	)
 }

--- a/x/posts/internal/types/events.go
+++ b/x/posts/internal/types/events.go
@@ -2,10 +2,10 @@ package types
 
 // Magpie module event types
 const (
-	EventTypeCreatePost = "create_post"
-	EventTypeEditPost   = "edit_post"
-	EventTypeLikePost   = "like_post"
-	EventTypeUnlikePost = "unlike_post"
+	EventTypePostCreated = "post_created"
+	EventTypePostEdited  = "post_edited"
+	EventTypePostLiked   = "post_liked"
+	EventTypePostUnliked = "post_unliked"
 
 	// Post attributes
 	AttributeKeyPostID       = "post_id"

--- a/x/posts/internal/types/like.go
+++ b/x/posts/internal/types/like.go
@@ -79,3 +79,27 @@ func (likes Likes) ContainsOwnerLike(owner sdk.AccAddress) bool {
 	}
 	return false
 }
+
+// IndexOfByOwner returns the index of the like having the
+// given owner inside the likes slice.
+func (likes Likes) IndexOfByOwner(owner sdk.AccAddress) int {
+	for index, like := range likes {
+		if like.Owner.Equals(owner) {
+			return index
+		}
+	}
+	return -1
+}
+
+// RemoveLikeOfOwner returns a new Likes slice not containing the
+// like of the given owner.
+// If the like was removed properly, true is also returned. Otherwise,
+// if no like was found, false is returned instead.
+func (likes Likes) RemoveLikeOfOwner(owner sdk.AccAddress) (Likes, bool) {
+	index := likes.IndexOfByOwner(owner)
+	if index == -1 {
+		return likes, false
+	}
+
+	return append(likes[:index], likes[index+1:]...), true
+}

--- a/x/posts/internal/types/like_test.go
+++ b/x/posts/internal/types/like_test.go
@@ -158,3 +158,83 @@ func TestLikes_ContainsOwnerLike(t *testing.T) {
 		})
 	}
 }
+
+func TestLikes_IndexOfByOwner(t *testing.T) {
+	liker, _ := sdk.AccAddressFromBech32("cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4")
+	otherLiker, _ := sdk.AccAddressFromBech32("cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae")
+	tests := []struct {
+		name     string
+		likes    types.Likes
+		owner    sdk.AccAddress
+		expIndex int
+	}{
+		{
+			name:     "Non-empty list returns proper index with valid value",
+			likes:    types.Likes{types.NewLike(1, liker)},
+			owner:    liker,
+			expIndex: 0,
+		},
+		{
+			name:     "Empty list returns -1",
+			likes:    types.Likes{},
+			owner:    liker,
+			expIndex: -1,
+		},
+		{
+			name:     "Non-empty list returns -1 with not found address",
+			likes:    types.Likes{types.NewLike(1, liker)},
+			owner:    otherLiker,
+			expIndex: -1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expIndex, test.likes.IndexOfByOwner(test.owner))
+		})
+	}
+}
+
+func TestLikes_RemoveLikeOfOwner(t *testing.T) {
+	liker, _ := sdk.AccAddressFromBech32("cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4")
+	otherLiker, _ := sdk.AccAddressFromBech32("cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae")
+	tests := []struct {
+		name      string
+		likes     types.Likes
+		owner     sdk.AccAddress
+		expResult types.Likes
+		expEdited bool
+	}{
+		{
+			name:      "Like is removed from non-empty list",
+			likes:     types.Likes{types.NewLike(1, liker)},
+			owner:     liker,
+			expResult: types.Likes{},
+			expEdited: true,
+		},
+		{
+			name:      "Empty list is not edited",
+			likes:     types.Likes{},
+			owner:     liker,
+			expResult: types.Likes{},
+			expEdited: false,
+		},
+		{
+			name:      "Non-empty list with not found address is not edited",
+			likes:     types.Likes{types.NewLike(1, liker)},
+			owner:     otherLiker,
+			expResult: types.Likes{types.NewLike(1, liker)},
+			expEdited: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result, edited := test.likes.RemoveLikeOfOwner(test.owner)
+			assert.Equal(t, test.expEdited, edited)
+			assert.Equal(t, test.expResult, result)
+		})
+	}
+}

--- a/x/posts/internal/types/post.go
+++ b/x/posts/internal/types/post.go
@@ -47,12 +47,12 @@ func (id *PostID) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	postId, err := ParsePostID(s)
+	postID, err := ParsePostID(s)
 	if err != nil {
 		return err
 	}
 
-	*id = postId
+	*id = postID
 	return nil
 }
 

--- a/x/posts/internal/types/post.go
+++ b/x/posts/internal/types/post.go
@@ -35,6 +35,27 @@ func (id PostID) Equals(other PostID) bool {
 	return id == other
 }
 
+// MarshalJSON implements Marshaler
+func (id PostID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(id.String())
+}
+
+// UnmarshalJSON implements Unmarshaler
+func (id *PostID) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	postId, err := ParsePostID(s)
+	if err != nil {
+		return err
+	}
+
+	*id = postId
+	return nil
+}
+
 // ParsePostID returns the PostID represented inside the provided
 // value, or an error if no id could be parsed properly
 func ParsePostID(value string) (PostID, error) {
@@ -75,8 +96,8 @@ func (ids PostIDs) Equals(other PostIDs) bool {
 
 // Post is a struct of a Magpie post
 type Post struct {
-	PostID            PostID         `json:"id,string"`          // Unique id
-	ParentID          PostID         `json:"parent_id,string"`   // Post of which this one is a comment
+	PostID            PostID         `json:"id"`                 // Unique id
+	ParentID          PostID         `json:"parent_id"`          // Post of which this one is a comment
 	Message           string         `json:"message"`            // Message contained inside the post
 	Created           sdk.Int        `json:"created"`            // Block height at which the post has been created
 	LastEdited        sdk.Int        `json:"last_edited"`        // Block height at which the post has been edited the last time

--- a/x/posts/internal/types/post_test.go
+++ b/x/posts/internal/types/post_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// -------------
+// --- PostID
+// -------------
+
+func TestPostID_MarshalJSON(t *testing.T) {
+	json := types.ModuleCdc.MustMarshalJSON(types.PostID(10))
+	assert.Equal(t, `"10"`, string(json))
+}
+
+func TestPostID_UnmarshalJSON(t *testing.T) {
+	var id types.PostID
+	types.ModuleCdc.MustUnmarshalJSON([]byte(`"10"`), &id)
+	assert.Equal(t, types.PostID(10), id)
+}
+
 // -----------
 // --- Post
 // -----------


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Added the handling for the already existing `MsgUnlikePost` as well as the CLI/REST transaction creation.  
Also, removed the emission of duplicated events and improved how events are returned from the handlers inside the `sdk.Result` type (this change avoid duplicated events to be returned). 

## Checklist
- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Re-reviewed `Files changed` in the Github PR explorer
