### PR TITLE
Replaced block height with timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Implemented the support for posts reactions (#47)
 - Implemented the support for posts subspaces (#46)
 - Automated the default bond denom change to `desmos` (#25)
+- Replaced the block height with timestamps inside posts' creation dates and edit dates (#62)
 
 ## Migration
 In order to migrate from version 0.1.0 to 0.2.0 of the chain, please run the following command:

--- a/docs/developers/msgs/create-post.md
+++ b/docs/developers/msgs/create-post.md
@@ -12,7 +12,7 @@ This message allows you to create a new public post.
     "subspace": "<Subspace of a post>",
     "optional_data": {},
     "creator": "<Desmos address that's creating the post>",
-    "creation_date": "<ISO 8601-formatted date representing the creation date of the post>"
+    "creation_date": "<RFC3339-formatted date representing the creation date of the post>"
   }
 }
 ```
@@ -26,7 +26,7 @@ This message allows you to create a new public post.
 | `susbspace` | String | Required string that identifies the posting app |
 | `optional_data` | Map | Optional arbitrary data that you might want to store |
 | `creator` | String | Desmos address of the user that is creating the post |
-| `creation_date` | String | Date in ISO 8601 format (e.g. `2020-01-01T12:00:00Z`) in which the post has been created. Cannot be a future date. |
+| `creation_date` | String | Date in RFC3339 format (e.g. `"2006-01-02T15:04:05Z07:00"`) in which the post has been created. Cannot be a future date. |
 
 ## Example
 ### With optional data

--- a/docs/developers/msgs/create-post.md
+++ b/docs/developers/msgs/create-post.md
@@ -11,7 +11,8 @@ This message allows you to create a new public post.
     "allows_comments": false,
     "subspace": "<Subspace of a post>",
     "optional_data": {},
-    "creator": "<Desmos address that's creating the post>"
+    "creator": "<Desmos address that's creating the post>",
+    "creation_date": "<ISO 8601-formatted date representing the creation date of the post>"
   }
 }
 ```
@@ -25,6 +26,7 @@ This message allows you to create a new public post.
 | `susbspace` | String | Required string that identifies the posting app |
 | `optional_data` | Map | Optional arbitrary data that you might want to store |
 | `creator` | String | Desmos address of the user that is creating the post |
+| `creation_date` | String | Date in ISO 8601 format (e.g. `2020-01-01T12:00:00Z`) in which the post has been created. Cannot be a future date. |
 
 ## Example
 ### With optional data
@@ -39,7 +41,8 @@ This message allows you to create a new public post.
     "optional_data": {
       "custom_field": "My custom value"
     },
-    "creator": "desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax"
+    "creator": "desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax",
+    "creation_date": "2020-01-01T12:00:00Z"
   }
 }
 ``` 
@@ -53,7 +56,8 @@ This message allows you to create a new public post.
     "message": "Desmos is great!",
     "allows_comments": true,
     "subspace": "desmos",
-    "creator": "desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax"
+    "creator": "desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax",
+    "creation_date": "2020-01-01T12:00:00Z"
   }
 }
 ```

--- a/docs/developers/msgs/edit-post.md
+++ b/docs/developers/msgs/edit-post.md
@@ -9,7 +9,7 @@ This message allows you to edit the message of a previously published public pos
     "post_id": "<ID of the post to be edited>",
     "message": "<New post message>",
     "editor": "<Desmos address of the user editing the message>",
-    "edit_date": "<ISO 8601-formatted date representing the date in which the post has been edited>"
+    "edit_date": "<RFC3339-formatted date representing the date in which the post has been edited>"
   }
 }
 ```
@@ -20,7 +20,7 @@ This message allows you to edit the message of a previously published public pos
 | `post_id` | String | ID of the post to edit |
 | `message` | String | New message that should be set as the post message |
 | `editor` | String | Desmos address of the user that is editing the post. This must be the same address of the original post creator. |
-| `edit_date` | String | Date in ISO 8601 format (e.g. `2020-01-01T12:00:00Z`) in which the post has been edited. This must be after the original post creation date and cannot be a future date. |
+| `edit_date` | String | Date in RFC3339 format (e.g. `"2006-01-02T15:04:05Z07:00"`) in which the post has been edited. This must be after the original post creation date and cannot be a future date. |
 
 ## Example
 ### With optional data

--- a/docs/developers/msgs/edit-post.md
+++ b/docs/developers/msgs/edit-post.md
@@ -1,0 +1,59 @@
+# `MsgEditPost`
+This message allows you to edit the message of a previously published public post.
+
+## Structure
+```json
+{
+  "type": "desmos/MsgEditPost",
+  "value": {
+    "post_id": "<ID of the post to be edited>",
+    "message": "<New post message>",
+    "editor": "<Desmos address of the user editing the message>",
+    "edit_date": "<ISO 8601-formatted date representing the date in which the post has been edited>"
+  }
+}
+```
+
+### Attributes
+| Attribute | Type | Description |
+| :-------: | :----: | :-------- |
+| `post_id` | String | ID of the post to edit |
+| `message` | String | New message that should be set as the post message |
+| `editor` | String | Desmos address of the user that is editing the post. This must be the same address of the original post creator. |
+| `edit_date` | String | Date in ISO 8601 format (e.g. `2020-01-01T12:00:00Z`) in which the post has been edited. This must be after the original post creation date and cannot be a future date. |
+
+## Example
+### With optional data
+```json
+{
+  "type": "desmos/MsgEditPost",
+  "value": {
+    "post_id": "1",
+    "message": "Desmos you rock!",
+    "editor": "desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax",
+    "edit_date": "2020-02-05T01:00:00"
+  }
+}
+``` 
+
+### Without optional data
+```json
+{
+  "type": "desmos/MsgCreatePost",
+  "value": {
+    "parent_id": "0",
+    "message": "Desmos is great!",
+    "allows_comments": true,
+    "subspace": "desmos",
+    "creator": "desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax",
+    "creation_date": "2020-01-01T12:00:00Z"
+  }
+}
+```
+
+## Message action
+The action associated to this message is the following: 
+
+```
+create_post
+```

--- a/docs/developers/perform-transactions.md
+++ b/docs/developers/perform-transactions.md
@@ -10,5 +10,6 @@ Here is the list of currently available [messages](developer-faq.md#what-is-a-me
 
 ### Posts
 * [`MsgCreatePost`](msgs/create-post.md): allows you to create a new post or a comment for an existing post. 
+* [`MsgEditPost](msgs/edit-post.md): allows you to edit a previously created post message.
 * [`MsgAddPostReaction`](msgs/add-reaction.md): allows you to add a reaction to an existing post. 
 * [`MsgRemoveReaction`](msgs/remove-reaction.md): allows you to remove a reaction from a post. 

--- a/docs/developers/queries/posts.md
+++ b/docs/developers/queries/posts.md
@@ -1,0 +1,36 @@
+# Query the stored posts
+This query endpoint allows you to get all the stored posts that match one or more filters. 
+
+**CLI**
+```shell
+desmoscli query posts [--flags]
+```
+
+Available flags: 
+- `--parent-id` (e.g. `--parent-id 5`)
+- `--creation-time` (e.g. `--creation-time 2020-01-01T12:00:00`)
+- `--allows-comments` (e.g. `--allows-comments true`)
+- `--subspace` (e.g. `--subspace desmos`)
+- `--creator` (e.g. `--creator desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax`)
+
+```shell
+# Example
+# desmoscli query posts --parent-id=1 --allows-comments=true --subspace=desmos
+```
+
+**REST**
+```shell
+/posts
+```
+
+Available parameters: 
+- `parent_id` (e.g. `parent_id=5`)
+- `creation_time` (e.g. `creation_time=2020-01-01T12:00:00`)
+- `allows_comments` (e.g. `allows_comments=true`)
+- `subspace` (e.g. `subspace=desmos`)
+- `creator` (e.g. `creator=desmos1w3fe8zq5jrxd4nz49hllg75sw7m24qyc7tnaax`)
+
+```shell
+# Example
+# curl https://morpheus1000.desmos.network/posts?parent_id=1&allows_comments=true&subspace=desmos
+```

--- a/docs/developers/query-data.md
+++ b/docs/developers/query-data.md
@@ -4,6 +4,7 @@ Aside from [performing transactions](perform-transactions.md) you can also query
 
 ## Posts
 - [Query a post](queries/post.md)
+- [Query the stored posts](queries/posts.md)
 
 ## Sessions
 - [Query a session](queries/session.md)

--- a/x/genutil/alias.go
+++ b/x/genutil/alias.go
@@ -1,0 +1,9 @@
+package genutil
+
+import (
+	"github.com/desmos-labs/desmos/x/genutil/internal/types"
+)
+
+type (
+	MigrationCallback = types.MigrationCallback
+)

--- a/x/genutil/client/cli/migrate.go
+++ b/x/genutil/client/cli/migrate.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -96,7 +97,7 @@ $ %s migrate v0.2.0 /path/to/genesis.json --chain-id=morpheus-XXXXX --genesis-ti
 				// v0.2.0 migration needs to have the previous version's genesis time and the
 				// block interval to convert the block height dates into timestamps
 				if target == "v0.2.0" && index == 0 {
-					blockInterval := cmd.Flag(flagBlockInterval).Value.String()
+					blockInterval, _ := strconv.Atoi(cmd.Flag(flagBlockInterval).Value.String())
 					newGenState = migration(newGenState, genDoc.GenesisTime, blockInterval)
 				} else {
 					newGenState = migration(newGenState)

--- a/x/genutil/client/cli/migrate.go
+++ b/x/genutil/client/cli/migrate.go
@@ -9,21 +9,23 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	extypes "github.com/cosmos/cosmos-sdk/x/genutil"
+	"github.com/desmos-labs/desmos/x/genutil/internal/types"
 	v020 "github.com/desmos-labs/desmos/x/genutil/legacy/v0.2.0"
 	"github.com/spf13/cobra"
-	"github.com/tendermint/tendermint/types"
+	tm "github.com/tendermint/tendermint/types"
 )
 
 // migrationMap contains the list of migrations that should be performed when migrating
 // a version of the chain to the next one. It contains an array as we need to support Cosmos SDK migrations
 // too if needed.
-var migrationMap = map[string][]extypes.MigrationCallback{
+var migrationMap = map[string][]types.MigrationCallback{
 	"v0.2.0": {v020.Migrate},
 }
 
 const (
-	flagGenesisTime = "genesis-time"
-	flagChainID     = "chain-id"
+	flagGenesisTime   = "genesis-time"
+	flagChainID       = "chain-id"
+	flagBlockInterval = "block-interval"
 )
 
 func MigrationsListCmd() *cobra.Command {
@@ -75,7 +77,7 @@ $ %s migrate v0.2.0 /path/to/genesis.json --chain-id=morpheus-XXXXX --genesis-ti
 			target := args[0]
 			importGenesis := args[1]
 
-			genDoc, err := types.GenesisDocFromFile(importGenesis)
+			genDoc, err := tm.GenesisDocFromFile(importGenesis)
 			if err != nil {
 				return err
 			}
@@ -89,8 +91,16 @@ $ %s migrate v0.2.0 /path/to/genesis.json --chain-id=morpheus-XXXXX --genesis-ti
 			}
 
 			newGenState := initialState
-			for _, migration := range migrations {
-				newGenState = migration(newGenState)
+			for index, migration := range migrations {
+
+				// v0.2.0 migration needs to have the previous version's genesis time and the
+				// block interval to convert the block height dates into timestamps
+				if target == "v0.2.0" && index == 0 {
+					blockInterval := cmd.Flag(flagBlockInterval).Value.String()
+					newGenState = migration(newGenState, genDoc.GenesisTime, blockInterval)
+				} else {
+					newGenState = migration(newGenState)
+				}
 			}
 
 			genDoc.AppState = cdc.MustMarshalJSON(newGenState)
@@ -124,6 +134,7 @@ $ %s migrate v0.2.0 /path/to/genesis.json --chain-id=morpheus-XXXXX --genesis-ti
 
 	cmd.Flags().String(flagGenesisTime, "", "Override genesis_time with this flag")
 	cmd.Flags().String(flagChainID, "", "Override chain_id with this flag")
+	cmd.Flags().Int(flagBlockInterval, 0, "Block interval of seconds to consider while computing timestamps dates")
 
 	return cmd
 }

--- a/x/genutil/internal/types/types.go
+++ b/x/genutil/internal/types/types.go
@@ -1,0 +1,9 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+)
+
+type (
+	MigrationCallback func(appMap genutil.AppMap, args ...interface{}) genutil.AppMap
+)

--- a/x/genutil/legacy/v0.2.0/migrate.go
+++ b/x/genutil/legacy/v0.2.0/migrate.go
@@ -1,6 +1,7 @@
 package v0_2_0
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -30,6 +31,9 @@ func Migrate(appState genutil.AppMap, args ...interface{}) genutil.AppMap {
 		// Get genesis time and block interval
 		genesisTime := args[0].(time.Time)
 		blockInterval := args[1].(int)
+		if blockInterval == 0 {
+			panic(fmt.Errorf("block interval cannot be 0 when migrating to v0.2.0, please set it using the --block-interval flag"))
+		}
 
 		appState[v020posts.ModuleName] = v020Codec.MustMarshalJSON(
 			v020posts.Migrate(genDocs, genesisTime, blockInterval),

--- a/x/genutil/legacy/v0.2.0/migrate.go
+++ b/x/genutil/legacy/v0.2.0/migrate.go
@@ -1,6 +1,8 @@
 package v0_2_0
 
 import (
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 
@@ -9,21 +11,28 @@ import (
 )
 
 // Migrate migrates exported state from v0.1.0 to a v0.2.0 genesis state.
-func Migrate(appState genutil.AppMap) genutil.AppMap {
+// It requires args to contain an integer value representing the block interval that should be considered when
+// converting block height-based timestamps into time.Time timestamps.
+func Migrate(appState genutil.AppMap, args ...interface{}) genutil.AppMap {
 	v010Codec := codec.New()
 	codec.RegisterCrypto(v010Codec)
 
 	v020Codec := codec.New()
 	codec.RegisterCrypto(v020Codec)
 
-	// Migrate docs state
+	// Migrate posts state
 	if appState[v010posts.ModuleName] != nil {
 		var genDocs v010posts.GenesisState
 		v010Codec.MustUnmarshalJSON(appState[v010posts.ModuleName], &genDocs)
 
 		delete(appState, v010posts.ModuleName) // delete old key in case the name changed
+
+		// Get genesis time and block interval
+		genesisTime := args[0].(time.Time)
+		blockInterval := args[1].(int)
+
 		appState[v020posts.ModuleName] = v020Codec.MustMarshalJSON(
-			v020posts.Migrate(genDocs),
+			v020posts.Migrate(genDocs, genesisTime, blockInterval),
 		)
 	}
 

--- a/x/posts/client/cli/query.go
+++ b/x/posts/client/cli/query.go
@@ -95,7 +95,7 @@ $ %s query posts posts --page=2 --limit=100
 
 			// CreationTime
 			if len(creationTime) > 0 {
-				parsedTime, err := time.Parse("2020-01-01T12:00:00Z", creationTime)
+				parsedTime, err := time.Parse(time.RFC3339, creationTime)
 				if err != nil {
 					return err
 				}

--- a/x/posts/client/cli/query.go
+++ b/x/posts/client/cli/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -75,7 +76,7 @@ $ %s query posts posts --page=2 --limit=100
 			limit := viper.GetInt(flagNumLimit)
 
 			parentID := viper.GetString(flagParentID)
-			creationTime := viper.GetInt(flagCreationTime)
+			creationTime := viper.GetString(flagCreationTime)
 			allowsComments := viper.GetString(flagAllowsComments)
 			subspace := viper.GetString(flagSubspace)
 			bech32CreatorAddress := viper.GetString(flagCreator)
@@ -93,8 +94,13 @@ $ %s query posts posts --page=2 --limit=100
 			}
 
 			// CreationTime
-			if creationTime >= 0 {
-				params.CreationTime = sdk.NewInt(int64(creationTime))
+			if len(creationTime) > 0 {
+				parsedTime, err := time.Parse("2020-01-01T12:00:00Z", creationTime)
+				if err != nil {
+					return err
+				}
+
+				params.CreationTime = &parsedTime
 			}
 
 			// AllowsComments
@@ -152,7 +158,7 @@ $ %s query posts posts --page=2 --limit=100
 	cmd.Flags().Int(flagNumLimit, 100, "pagination limit of posts to query for")
 
 	cmd.Flags().String(flagParentID, "", "(optional) filter the posts with given parent id")
-	cmd.Flags().Int(flagCreationTime, -1, "(optional) filter the posts created at block height")
+	cmd.Flags().String(flagCreationTime, "", "(optional) filter the posts created at block height")
 	cmd.Flags().String(flagAllowsComments, "", "(optional) filter the posts allowing comments")
 	cmd.Flags().String(flagSubspace, "", "(optional) filter the posts part of the subspace")
 	cmd.Flags().String(flagCreator, "", "(optional) filter the posts created by creator")

--- a/x/posts/client/cli/tx.go
+++ b/x/posts/client/cli/tx.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/viper"
@@ -66,7 +67,7 @@ func GetCmdCreatePost(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgCreatePost(args[1], parentID, allowsComments, args[0], map[string]string{}, from)
+			msg := types.NewMsgCreatePost(args[1], parentID, allowsComments, args[0], map[string]string{}, from, time.Now())
 			if err = msg.ValidateBasic(); err != nil {
 				return err
 			}
@@ -102,7 +103,7 @@ func GetCmdEditPost(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgEditPost(postID, args[1], from)
+			msg := types.NewMsgEditPost(postID, args[1], from, time.Now())
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/posts/client/rest/query.go
+++ b/x/posts/client/rest/query.go
@@ -77,7 +77,7 @@ func queryPostsWithParameterHandlerFn(cliCtx context.CLIContext) http.HandlerFun
 		}
 
 		if v := r.URL.Query().Get(RestCreationTime); len(v) != 0 {
-			creationTime, err = time.Parse("2020-01-01T12:00:00Z", v)
+			creationTime, err = time.Parse(time.RFC3339, v)
 			if err != nil {
 				rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 				return

--- a/x/posts/client/rest/query.go
+++ b/x/posts/client/rest/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -60,7 +61,7 @@ func queryPostsWithParameterHandlerFn(cliCtx context.CLIContext) http.HandlerFun
 
 		var (
 			parentID       *types.PostID
-			creationTime   sdk.Int
+			creationTime   time.Time
 			allowsComments bool
 			subspace       string
 			creatorAddr    sdk.AccAddress
@@ -76,9 +77,9 @@ func queryPostsWithParameterHandlerFn(cliCtx context.CLIContext) http.HandlerFun
 		}
 
 		if v := r.URL.Query().Get(RestCreationTime); len(v) != 0 {
-			creationTime, ok = sdk.NewIntFromString(v)
-			if !ok {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("cannot parse int: %s", v))
+			creationTime, err = time.Parse("2020-01-01T12:00:00Z", v)
+			if err != nil {
+				rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 				return
 			}
 		}

--- a/x/posts/client/rest/rest.go
+++ b/x/posts/client/rest/rest.go
@@ -1,6 +1,8 @@
 package rest
 
 import (
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
@@ -20,6 +22,7 @@ type CreatePostReq struct {
 	AllowsComments bool              `json:"allows_comments"`
 	Subspace       string            `json:"subspace"`
 	OptionalData   map[string]string `json:"optional_data"`
+	CreationTime   time.Time         `json:"creation_time"`
 }
 
 // AddReactionReq defines the properties of a reaction adding request's body.

--- a/x/posts/client/rest/tx.go
+++ b/x/posts/client/rest/tx.go
@@ -44,7 +44,7 @@ func createPostHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		msg := types.NewMsgCreatePost(req.Message, parentID, req.AllowsComments, req.Subspace, req.OptionalData, addr)
+		msg := types.NewMsgCreatePost(req.Message, parentID, req.AllowsComments, req.Subspace, req.OptionalData, addr, req.CreationTime)
 		err = msg.ValidateBasic()
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/x/posts/internal/keeper/common_test.go
+++ b/x/posts/internal/keeper/common_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -42,6 +44,8 @@ func testCodec() *codec.Codec {
 }
 
 var testPostOwner, _ = sdk.AccAddressFromBech32("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
+var timeZone, _ = time.LoadLocation("UTC")
+var testPostCreationDate = time.Date(2020, 1, 1, 15, 15, 00, 000, timeZone)
 var testPost = types.NewPost(
 	types.PostID(3257),
 	types.PostID(0),
@@ -49,6 +53,6 @@ var testPost = types.NewPost(
 	false,
 	"desmos",
 	map[string]string{},
-	10,
+	testPostCreationDate,
 	testPostOwner,
 )

--- a/x/posts/internal/keeper/handler.go
+++ b/x/posts/internal/keeper/handler.go
@@ -35,7 +35,7 @@ func handleMsgCreatePost(ctx sdk.Context, keeper Keeper, msg types.MsgCreatePost
 		msg.AllowsComments,
 		msg.Subspace,
 		msg.OptionalData,
-		ctx.BlockHeight(),
+		msg.CreationDate,
 		msg.Creator,
 	)
 
@@ -88,13 +88,13 @@ func handleMsgEditPost(ctx sdk.Context, keeper Keeper, msg types.MsgEditPost) sd
 	}
 
 	// Check the validity of the current block height respect to the creation date of the post
-	if existing.Created.GT(sdk.NewInt(ctx.BlockHeight())) {
+	if existing.Created.After(msg.EditDate) {
 		return sdk.ErrUnknownRequest("Edit date cannot be before creation date").Result()
 	}
 
 	// Edit the post
 	existing.Message = msg.Message
-	existing.LastEdited = sdk.NewInt(ctx.BlockHeight())
+	existing.LastEdited = msg.EditDate
 	keeper.SavePost(ctx, existing)
 
 	editEvent := sdk.NewEvent(
@@ -119,7 +119,7 @@ func handleMsgAddPostReaction(ctx sdk.Context, keeper Keeper, msg types.MsgAddPo
 	}
 
 	// Create and store the reaction
-	reaction := types.NewReaction(msg.Value, ctx.BlockHeight(), msg.User)
+	reaction := types.NewReaction(msg.Value, msg.User)
 	if err := keeper.SaveReaction(ctx, post.PostID, reaction); err != nil {
 		return err.Result()
 	}

--- a/x/posts/internal/keeper/keeper.go
+++ b/x/posts/internal/keeper/keeper.go
@@ -128,7 +128,7 @@ func (k Keeper) GetPostsFiltered(ctx sdk.Context, params types.QueryPostsParams)
 		}
 
 		// match creation time if valid height
-		if params.CreationTime.GTE(sdk.ZeroInt()) {
+		if params.CreationTime != nil {
 			matchCreationTime = params.CreationTime.Equal(p.Created)
 		}
 

--- a/x/posts/internal/keeper/keeper_test.go
+++ b/x/posts/internal/keeper/keeper_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/desmos-labs/desmos/x/posts/internal/types"
@@ -56,25 +57,25 @@ func TestKeeper_SavePost(t *testing.T) {
 		{
 			name: "Post with ID already present",
 			existingPosts: types.Posts{
-				types.NewPost(types.PostID(1), types.PostID(0), "Post", false, "desmos", map[string]string{}, 0, testPostOwner),
+				types.NewPost(types.PostID(1), types.PostID(0), "Post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			},
-			newPost:              types.NewPost(types.PostID(1), types.PostID(0), "New post", false, "desmos", map[string]string{}, 0, testPostOwner),
+			newPost:              types.NewPost(types.PostID(1), types.PostID(0), "New post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			expParentCommentsIDs: []types.PostID{},
 		},
 		{
 			name: "Post which ID is not already present",
 			existingPosts: types.Posts{
-				types.NewPost(types.PostID(1), types.PostID(0), "Post", false, "desmos", map[string]string{}, 0, testPostOwner),
+				types.NewPost(types.PostID(1), types.PostID(0), "Post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			},
-			newPost:              types.NewPost(types.PostID(15), types.PostID(0), "New post", false, "desmos", map[string]string{}, 0, testPostOwner),
+			newPost:              types.NewPost(types.PostID(15), types.PostID(0), "New post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			expParentCommentsIDs: []types.PostID{},
 		},
 		{
 			name: "Post with valid parent ID",
 			existingPosts: []types.Post{
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "desmos", map[string]string{}, 0, testPostOwner),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			},
-			newPost:              types.NewPost(types.PostID(15), types.PostID(1), "Comment", false, "desmos", map[string]string{}, 0, testPostOwner),
+			newPost:              types.NewPost(types.PostID(15), types.PostID(1), "Comment", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			expParentCommentsIDs: []types.PostID{types.PostID(15)},
 		},
 	}
@@ -126,7 +127,7 @@ func TestKeeper_GetPost(t *testing.T) {
 			name:       "Existing post is found properly",
 			ID:         types.PostID(45),
 			postExists: true,
-			expected:   types.NewPost(types.PostID(45), types.PostID(0), "Post", false, "desmos", map[string]string{}, 0, testPostOwner),
+			expected:   types.NewPost(types.PostID(45), types.PostID(0), "Post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 		},
 	}
 
@@ -164,11 +165,11 @@ func TestKeeper_GetPostChildrenIDs(t *testing.T) {
 		{
 			name: "Non empty children list is returned properly",
 			storedPosts: types.Posts{
-				types.NewPost(types.PostID(10), types.PostID(0), "Original post", false, "desmos", map[string]string{}, 10, testPost.Creator),
-				types.NewPost(types.PostID(55), types.PostID(10), "First commit", false, "desmos", map[string]string{}, 10, testPost.Creator),
-				types.NewPost(types.PostID(78), types.PostID(10), "Other commit", false, "desmos", map[string]string{}, 10, testPost.Creator),
-				types.NewPost(types.PostID(11), types.PostID(0), "Second post", false, "desmos", map[string]string{}, 10, testPost.Creator),
-				types.NewPost(types.PostID(104), types.PostID(11), "Comment to second post", false, "desmos", map[string]string{}, 10, testPost.Creator),
+				types.NewPost(types.PostID(10), types.PostID(0), "Original post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
+				types.NewPost(types.PostID(55), types.PostID(10), "First commit", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
+				types.NewPost(types.PostID(78), types.PostID(10), "Other commit", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
+				types.NewPost(types.PostID(11), types.PostID(0), "Second post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
+				types.NewPost(types.PostID(104), types.PostID(11), "Comment to second post", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			},
 			postID:         types.PostID(10),
 			expChildrenIDs: types.PostIDs{types.PostID(55), types.PostID(78)},
@@ -206,8 +207,8 @@ func TestKeeper_GetPosts(t *testing.T) {
 		{
 			name: "Existing list is returned properly",
 			posts: types.Posts{
-				types.NewPost(types.PostID(13), types.PostID(0), "", false, "desmos", map[string]string{}, 0, testPostOwner),
-				types.NewPost(types.PostID(76), types.PostID(0), "", false, "desmos", map[string]string{}, 0, testPostOwner),
+				types.NewPost(types.PostID(13), types.PostID(0), "", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
+				types.NewPost(types.PostID(76), types.PostID(0), "", false, "desmos", map[string]string{}, testPost.Created, testPost.Creator),
 			},
 		},
 	}
@@ -231,13 +232,43 @@ func TestKeeper_GetPosts(t *testing.T) {
 func TestKeeper_GetPostsFiltered(t *testing.T) {
 	boolTrue := true
 
-	var creator1, _ = sdk.AccAddressFromBech32("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
-	var creator2, _ = sdk.AccAddressFromBech32("cosmos1jlhazemxvu0zn9y77j6afwmpf60zveqw5480l2")
+	creator1, _ := sdk.AccAddressFromBech32("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
+	creator2, _ := sdk.AccAddressFromBech32("cosmos1jlhazemxvu0zn9y77j6afwmpf60zveqw5480l2")
+
+	timeZone, _ := time.LoadLocation("UTC")
+	date := time.Date(2020, 1, 1, 1, 1, 0, 0, timeZone)
 
 	posts := types.Posts{
-		types.NewPost(types.PostID(10), types.PostID(1), "Post 1", false, "", map[string]string{}, 15, creator1),
-		types.NewPost(types.PostID(11), types.PostID(1), "Post 2", true, "desmos", map[string]string{}, 17, creator2),
-		types.NewPost(types.PostID(12), types.PostID(2), "Post 3", false, "desmos", map[string]string{}, 15, creator2),
+		types.NewPost(
+			types.PostID(10),
+			types.PostID(1),
+			"Post 1",
+			false,
+			"",
+			map[string]string{},
+			date,
+			creator1,
+		),
+		types.NewPost(
+			types.PostID(11),
+			types.PostID(1),
+			"Post 2",
+			true,
+			"desmos",
+			map[string]string{},
+			time.Date(2020, 2, 1, 1, 1, 0, 0, timeZone),
+			creator2,
+		),
+		types.NewPost(
+			types.PostID(12),
+			types.PostID(2),
+			"Post 3",
+			false,
+			"desmos",
+			map[string]string{},
+			date,
+			creator2,
+		),
 	}
 
 	tests := []struct {
@@ -262,27 +293,27 @@ func TestKeeper_GetPostsFiltered(t *testing.T) {
 		},
 		{
 			name:     "Parent ID matcher works properly",
-			filter:   types.QueryPostsParams{Page: 1, Limit: 5, CreationTime: sdk.NewInt(-1), ParentID: &posts[0].ParentID},
+			filter:   types.QueryPostsParams{Page: 1, Limit: 5, ParentID: &posts[0].ParentID},
 			expected: types.Posts{posts[0], posts[1]},
 		},
 		{
 			name:     "Creation time matcher works properly",
-			filter:   types.QueryPostsParams{Page: 1, Limit: 5, CreationTime: sdk.NewInt(15)},
+			filter:   types.QueryPostsParams{Page: 1, Limit: 5, CreationTime: &date},
 			expected: types.Posts{posts[0], posts[2]},
 		},
 		{
 			name:     "Allows comments matcher works properly",
-			filter:   types.QueryPostsParams{Page: 1, Limit: 5, CreationTime: sdk.NewInt(-1), AllowsComments: &boolTrue},
+			filter:   types.QueryPostsParams{Page: 1, Limit: 5, AllowsComments: &boolTrue},
 			expected: types.Posts{posts[1]},
 		},
 		{
 			name:     "Subspace mather works properly",
-			filter:   types.QueryPostsParams{Page: 1, Limit: 5, CreationTime: sdk.NewInt(-1), Subspace: "desmos"},
+			filter:   types.QueryPostsParams{Page: 1, Limit: 5, Subspace: "desmos"},
 			expected: types.Posts{posts[1], posts[2]},
 		},
 		{
 			name:     "Creator mather works properly",
-			filter:   types.QueryPostsParams{Page: 1, Limit: 5, CreationTime: sdk.NewInt(-1), Creator: creator2},
+			filter:   types.QueryPostsParams{Page: 1, Limit: 5, Creator: creator2},
 			expected: types.Posts{posts[1], posts[2]},
 		},
 	}
@@ -322,29 +353,29 @@ func TestKeeper_SaveReaction(t *testing.T) {
 	}{
 		{
 			name:           "Reaction from same user already present returns expError",
-			storedLikes:    types.Reactions{types.NewReaction("like", 10, liker)},
+			storedLikes:    types.Reactions{types.NewReaction("like", liker)},
 			postID:         types.PostID(10),
-			like:           types.NewReaction("like", 50, liker),
+			like:           types.NewReaction("like", liker),
 			error:          sdk.ErrUnknownRequest("cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4 has already reacted with like to the post with id 10"),
-			expectedStored: types.Reactions{types.NewReaction("like", 10, liker)},
+			expectedStored: types.Reactions{types.NewReaction("like", liker)},
 		},
 		{
 			name:           "First liker is stored properly",
 			storedLikes:    types.Reactions{},
 			postID:         types.PostID(15),
-			like:           types.NewReaction("like", 15, liker),
+			like:           types.NewReaction("like", liker),
 			error:          nil,
-			expectedStored: types.Reactions{types.NewReaction("like", 15, liker)},
+			expectedStored: types.Reactions{types.NewReaction("like", liker)},
 		},
 		{
 			name:        "Second liker is stored properly",
-			storedLikes: types.Reactions{types.NewReaction("like", 10, liker)},
+			storedLikes: types.Reactions{types.NewReaction("like", liker)},
 			postID:      types.PostID(87),
-			like:        types.NewReaction("like", 1, otherLiker),
+			like:        types.NewReaction("like", otherLiker),
 			error:       nil,
 			expectedStored: types.Reactions{
-				types.NewReaction("like", 10, liker),
-				types.NewReaction("like", 1, otherLiker),
+				types.NewReaction("like", liker),
+				types.NewReaction("like", otherLiker),
 			},
 		},
 	}
@@ -383,7 +414,7 @@ func TestKeeper_RemoveReaction(t *testing.T) {
 	}{
 		{
 			name:           "Reaction from same liker is removed properly",
-			storedLikes:    types.Reactions{types.NewReaction("like", 10, liker)},
+			storedLikes:    types.Reactions{types.NewReaction("like", liker)},
 			postID:         types.PostID(10),
 			liker:          liker,
 			value:          "like",
@@ -401,12 +432,12 @@ func TestKeeper_RemoveReaction(t *testing.T) {
 		},
 		{
 			name:           "Non existing like returned expError - Reaction",
-			storedLikes:    types.Reactions{types.NewReaction("like", 10, liker)},
+			storedLikes:    types.Reactions{types.NewReaction("like", liker)},
 			postID:         types.PostID(15),
 			liker:          liker,
 			value:          "reaction",
 			error:          sdk.ErrUnauthorized("Cannot remove the reaction with value reaction from user cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4 as it does not exist"),
-			expectedStored: types.Reactions{types.NewReaction("like", 10, liker)},
+			expectedStored: types.Reactions{types.NewReaction("like", liker)},
 		},
 	}
 
@@ -451,8 +482,8 @@ func TestKeeper_GetPostLikes(t *testing.T) {
 		{
 			name: "Valid list of likes is returned properly",
 			likes: types.Reactions{
-				types.NewReaction("like", 11, otherLiker),
-				types.NewReaction("like", 10, liker),
+				types.NewReaction("like", otherLiker),
+				types.NewReaction("like", liker),
 			},
 		},
 	}
@@ -492,11 +523,11 @@ func TestKeeper_GetLikes(t *testing.T) {
 			name: "Non empty likes data are returned correcly",
 			likes: map[types.PostID]types.Reactions{
 				types.PostID(5): {
-					types.NewReaction("like", 10, liker1),
-					types.NewReaction("like", 50, liker2),
+					types.NewReaction("like", liker1),
+					types.NewReaction("like", liker2),
 				},
 				types.PostID(10): {
-					types.NewReaction("like", 5, liker1),
+					types.NewReaction("like", liker1),
 				},
 			},
 		},

--- a/x/posts/internal/keeper/keeper_test.go
+++ b/x/posts/internal/keeper/keeper_test.go
@@ -88,20 +88,20 @@ func TestKeeper_SavePost(t *testing.T) {
 		{
 			name: "Post with ID greater ID than Last ID stored",
 			existingPosts: types.Posts{
-				types.NewPost(types.PostID(4), types.PostID(0), "Post lesser", false, "desmos", map[string]string{}, 0, testPostOwner),
+				types.NewPost(types.PostID(4), types.PostID(0), "Post lesser", false, "desmos", map[string]string{}, testPost.Created, testPostOwner),
 			},
 			lastPostID:           types.PostID(4),
-			newPost:              types.NewPost(types.PostID(5), types.PostID(0), "New post greater", false, "desmos", map[string]string{}, 0, testPostOwner),
+			newPost:              types.NewPost(types.PostID(5), types.PostID(0), "New post greater", false, "desmos", map[string]string{}, testPost.Created, testPostOwner),
 			expParentCommentsIDs: []types.PostID{},
 			expLastID:            types.PostID(5),
 		},
 		{
 			name: "Post with ID lesser ID than Last ID stored",
 			existingPosts: types.Posts{
-				types.NewPost(types.PostID(4), types.PostID(0), "Post ID greater", false, "desmos", map[string]string{}, 0, testPostOwner),
+				types.NewPost(types.PostID(4), types.PostID(0), "Post ID greater", false, "desmos", map[string]string{}, testPost.Created, testPostOwner),
 			},
 			lastPostID:           types.PostID(4),
-			newPost:              types.NewPost(types.PostID(3), types.PostID(0), "New post ID lesser", false, "desmos", map[string]string{}, 0, testPostOwner),
+			newPost:              types.NewPost(types.PostID(3), types.PostID(0), "New post ID lesser", false, "desmos", map[string]string{}, testPost.Created, testPostOwner),
 			expParentCommentsIDs: []types.PostID{},
 			expLastID:            types.PostID(4),
 		},

--- a/x/posts/internal/keeper/querier_test.go
+++ b/x/posts/internal/keeper/querier_test.go
@@ -35,12 +35,12 @@ func Test_queryPost(t *testing.T) {
 		{
 			name: "Post without likes is returned properly",
 			storedPosts: types.Posts{
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
-				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
+				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, testPost.Created, creator),
 			},
 			path: []string{types.QueryPost, "1"},
 			expResult: types.NewPostResponse(
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
 				types.Reactions{},
 				types.PostIDs{types.PostID(2)},
 			),
@@ -48,11 +48,11 @@ func Test_queryPost(t *testing.T) {
 		{
 			name: "Post without children is returned properly",
 			storedPosts: types.Posts{
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
 			},
 			path: []string{types.QueryPost, "1"},
 			expResult: types.NewPostResponse(
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
 				types.Reactions{},
 				types.PostIDs{},
 			),
@@ -60,21 +60,21 @@ func Test_queryPost(t *testing.T) {
 		{
 			name: "Post with all data is returned properly",
 			storedPosts: types.Posts{
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
-				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
+				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, testPost.Created, creator),
 			},
 			storedReactions: map[types.PostID]types.Reactions{
 				types.PostID(1): {
-					types.NewReaction("Like", 0, creator),
-					types.NewReaction("Like", 10, otherCreator),
+					types.NewReaction("Like", creator),
+					types.NewReaction("Like", otherCreator),
 				},
 			},
 			path: []string{types.QueryPost, "1"},
 			expResult: types.NewPostResponse(
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
 				types.Reactions{
-					types.NewReaction("Like", 0, creator),
-					types.NewReaction("Like", 10, otherCreator),
+					types.NewReaction("Like", creator),
+					types.NewReaction("Like", otherCreator),
 				},
 				types.PostIDs{types.PostID(2)},
 			),
@@ -122,18 +122,18 @@ func Test_queryPosts(t *testing.T) {
 		{
 			name: "Empty params returns all",
 			storedPosts: types.Posts{
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
-				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
+				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, testPost.Created, creator),
 			},
 			params: types.QueryPostsParams{},
 			expResponse: []types.PostQueryResponse{
 				types.NewPostResponse(
-					types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
+					types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
 					types.Reactions{},
 					types.PostIDs{types.PostID(2)},
 				),
 				types.NewPostResponse(
-					types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, 0, creator),
+					types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, testPost.Created, creator),
 					types.Reactions{},
 					types.PostIDs{},
 				),
@@ -142,13 +142,13 @@ func Test_queryPosts(t *testing.T) {
 		{
 			name: "Non empty params return proper posts",
 			storedPosts: types.Posts{
-				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
-				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, 0, creator),
+				types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
+				types.NewPost(types.PostID(2), types.PostID(1), "Child", false, "", map[string]string{}, testPost.Created, creator),
 			},
 			params: types.DefaultQueryPostsParams(1, 1),
 			expResponse: []types.PostQueryResponse{
 				types.NewPostResponse(
-					types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, 0, creator),
+					types.NewPost(types.PostID(1), types.PostID(0), "Parent", false, "", map[string]string{}, testPost.Created, creator),
 					types.Reactions{},
 					types.PostIDs{types.PostID(2)},
 				),

--- a/x/posts/internal/types/msgs.go
+++ b/x/posts/internal/types/msgs.go
@@ -80,6 +80,10 @@ func (msg MsgCreatePost) ValidateBasic() sdk.Error {
 		return sdk.ErrUnknownRequest("Invalid post creation date")
 	}
 
+	if msg.CreationDate.After(time.Now()) {
+		return sdk.ErrUnknownRequest("Creation date cannot be in the future")
+	}
+
 	return nil
 }
 
@@ -131,12 +135,16 @@ func (msg MsgEditPost) ValidateBasic() sdk.Error {
 		return sdk.ErrInvalidAddress(fmt.Sprintf("Invalid editor address: %s", msg.Editor))
 	}
 
-	if len(msg.Message) == 0 {
-		return sdk.ErrUnknownRequest("Post message cannot be empty")
+	if len(strings.TrimSpace(msg.Message)) == 0 {
+		return sdk.ErrUnknownRequest("Post message cannot be empty nor blank")
 	}
 
 	if msg.EditDate.IsZero() {
 		return sdk.ErrUnknownRequest("Invalid edit date")
+	}
+
+	if msg.EditDate.After(time.Now()) {
+		return sdk.ErrUnknownRequest("Edit date cannot be in the future")
 	}
 
 	return nil

--- a/x/posts/internal/types/msgs.go
+++ b/x/posts/internal/types/msgs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -20,11 +21,12 @@ type MsgCreatePost struct {
 	Subspace       string            `json:"subspace"`
 	OptionalData   map[string]string `json:"optional_data,omitempty"`
 	Creator        sdk.AccAddress    `json:"creator"`
+	CreationDate   time.Time         `json:"creation_date"`
 }
 
 // NewMsgCreatePost is a constructor function for MsgSetName
 func NewMsgCreatePost(message string, parentID PostID, allowsComments bool, subspace string,
-	optionalData map[string]string, owner sdk.AccAddress) MsgCreatePost {
+	optionalData map[string]string, owner sdk.AccAddress, creationDate time.Time) MsgCreatePost {
 	return MsgCreatePost{
 		Message:        message,
 		ParentID:       parentID,
@@ -32,6 +34,7 @@ func NewMsgCreatePost(message string, parentID PostID, allowsComments bool, subs
 		Subspace:       subspace,
 		OptionalData:   optionalData,
 		Creator:        owner,
+		CreationDate:   creationDate,
 	}
 }
 
@@ -72,6 +75,11 @@ func (msg MsgCreatePost) ValidateBasic() sdk.Error {
 			return sdk.ErrUnknownRequest(msg)
 		}
 	}
+
+	if msg.CreationDate.IsZero() {
+		return sdk.ErrUnknownRequest("Invalid post creation date")
+	}
+
 	return nil
 }
 
@@ -91,17 +99,19 @@ func (msg MsgCreatePost) GetSigners() []sdk.AccAddress {
 
 // MsgEditPost defines the EditPostMessage message
 type MsgEditPost struct {
-	PostID  PostID         `json:"post_id"`
-	Message string         `json:"message"`
-	Editor  sdk.AccAddress `json:"editor"`
+	PostID   PostID         `json:"post_id"`
+	Message  string         `json:"message"`
+	Editor   sdk.AccAddress `json:"editor"`
+	EditDate time.Time      `json:"edit_date"`
 }
 
 // NewMsgEditPost is the constructor function for MsgEditPost
-func NewMsgEditPost(id PostID, message string, owner sdk.AccAddress) MsgEditPost {
+func NewMsgEditPost(id PostID, message string, owner sdk.AccAddress, editDate time.Time) MsgEditPost {
 	return MsgEditPost{
-		PostID:  id,
-		Message: message,
-		Editor:  owner,
+		PostID:   id,
+		Message:  message,
+		Editor:   owner,
+		EditDate: editDate,
 	}
 }
 
@@ -123,6 +133,10 @@ func (msg MsgEditPost) ValidateBasic() sdk.Error {
 
 	if len(msg.Message) == 0 {
 		return sdk.ErrUnknownRequest("Post message cannot be empty")
+	}
+
+	if msg.EditDate.IsZero() {
+		return sdk.ErrUnknownRequest("Invalid edit date")
 	}
 
 	return nil

--- a/x/posts/internal/types/msgs_test.go
+++ b/x/posts/internal/types/msgs_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/desmos-labs/desmos/x/posts/internal/types"
@@ -13,8 +14,16 @@ import (
 // ----------------------
 
 var testOwner, _ = sdk.AccAddressFromBech32("cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")
+var timeZone, _ = time.LoadLocation("UTC")
+var date = time.Date(2020, 1, 1, 12, 0, 0, 0, timeZone)
 var msgCreatePost = types.NewMsgCreatePost(
-	"My new post", types.PostID(53), false, "desmos", map[string]string{}, testOwner,
+	"My new post",
+	types.PostID(53),
+	false,
+	"desmos",
+	map[string]string{},
+	testOwner,
+	date,
 )
 
 func TestMsgCreatePost_Route(t *testing.T) {
@@ -36,17 +45,17 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 	}{
 		{
 			name:  "Empty owner returns error",
-			msg:   types.NewMsgCreatePost("Message", types.PostID(0), false, "desmos", map[string]string{}, nil),
+			msg:   types.NewMsgCreatePost("Message", types.PostID(0), false, "desmos", map[string]string{}, nil, date),
 			error: sdk.ErrInvalidAddress("Invalid creator address: "),
 		},
 		{
 			name:  "Empty message returns error",
-			msg:   types.NewMsgCreatePost("", types.PostID(0), false, "desmos", map[string]string{}, creator),
+			msg:   types.NewMsgCreatePost("", types.PostID(0), false, "desmos", map[string]string{}, creator, date),
 			error: sdk.ErrUnknownRequest("Post message cannot be empty nor blank"),
 		},
 		{
 			name:  "Empty subspace returns error",
-			msg:   types.NewMsgCreatePost("My message", types.PostID(0), false, "", map[string]string{}, creator),
+			msg:   types.NewMsgCreatePost("My message", types.PostID(0), false, "", map[string]string{}, creator, date),
 			error: sdk.ErrUnknownRequest("Post subspace cannot be empty nor blank"),
 		},
 		{
@@ -70,6 +79,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 					"key11": "value11",
 				},
 				creator,
+				date,
 			),
 			error: sdk.ErrUnknownRequest("Post optional data cannot be longer than 10 fields"),
 		},
@@ -84,6 +94,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 					"key1": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ac ullamcorper dui, a mattis sapien. Vivamus sed massa eget felis hendrerit ultrices. Morbi pretium hendrerit nisi quis faucibus volutpat.",
 				},
 				creator,
+				date,
 			),
 			error: sdk.ErrUnknownRequest("Post optional data value lengths cannot be longer than 200. key1 exceeds the limit"),
 		},
@@ -104,6 +115,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 					"array":  `["first","second"]`,
 				},
 				creator,
+				date,
 			),
 			error: nil,
 		},
@@ -128,13 +140,13 @@ func TestMsgCreatePost_GetSignBytes(t *testing.T) {
 	}{
 		{
 			name:        "Message with non-empty external reference",
-			msg:         types.NewMsgCreatePost("My new post", types.PostID(53), false, "desmos", map[string]string{"field": "value"}, testOwner),
-			expSignJSON: `{"type":"desmos/MsgCreatePost","value":{"allows_comments":false,"creator":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"My new post","optional_data":{"field":"value"},"parent_id":"53","subspace":"desmos"}}`,
+			msg:         types.NewMsgCreatePost("My new post", types.PostID(53), false, "desmos", map[string]string{"field": "value"}, testOwner, date),
+			expSignJSON: `{"type":"desmos/MsgCreatePost","value":{"allows_comments":false,"creation_date":"2020-01-01T12:00:00Z","creator":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"My new post","optional_data":{"field":"value"},"parent_id":"53","subspace":"desmos"}}`,
 		},
 		{
 			name:        "Message with non-empty external reference",
-			msg:         types.NewMsgCreatePost("My post", types.PostID(15), false, "desmos", map[string]string{}, testOwner),
-			expSignJSON: `{"type":"desmos/MsgCreatePost","value":{"allows_comments":false,"creator":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"My post","parent_id":"15","subspace":"desmos"}}`,
+			msg:         types.NewMsgCreatePost("My post", types.PostID(15), false, "desmos", map[string]string{}, testOwner, date),
+			expSignJSON: `{"type":"desmos/MsgCreatePost","value":{"allows_comments":false,"creation_date":"2020-01-01T12:00:00Z","creator":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"My post","parent_id":"15","subspace":"desmos"}}`,
 		},
 	}
 
@@ -156,7 +168,8 @@ func TestMsgCreatePost_GetSigners(t *testing.T) {
 // --- MsgEditPost
 // ----------------------
 
-var msgEditPost = types.NewMsgEditPost(types.PostID(94), "Edited post message", testOwner)
+var editDate = time.Date(2020, 2, 2, 15, 0, 0, 0, timeZone)
+var msgEditPost = types.NewMsgEditPost(types.PostID(94), "Edited post message", testOwner, editDate)
 
 func TestMsgEditPost_Route(t *testing.T) {
 	actual := msgEditPost.Route()
@@ -176,22 +189,22 @@ func TestMsgEditPost_ValidateBasic(t *testing.T) {
 	}{
 		{
 			name:  "Invalid post id returns error",
-			msg:   types.NewMsgEditPost(types.PostID(0), "Edited post message", testOwner),
+			msg:   types.NewMsgEditPost(types.PostID(0), "Edited post message", testOwner, editDate),
 			error: sdk.ErrUnknownRequest("Invalid post id"),
 		},
 		{
 			name:  "Invalid editor returns error",
-			msg:   types.NewMsgEditPost(types.PostID(10), "Edited post message", nil),
+			msg:   types.NewMsgEditPost(types.PostID(10), "Edited post message", nil, editDate),
 			error: sdk.ErrInvalidAddress("Invalid editor address: "),
 		},
 		{
 			name:  "Invalid message returns error",
-			msg:   types.NewMsgEditPost(types.PostID(10), "", testOwner),
+			msg:   types.NewMsgEditPost(types.PostID(10), "", testOwner, editDate),
 			error: sdk.ErrUnknownRequest("Post message cannot be empty"),
 		},
 		{
 			name:  "Valid message returns no error",
-			msg:   types.NewMsgEditPost(types.PostID(10), "Edited post message", testOwner),
+			msg:   types.NewMsgEditPost(types.PostID(10), "Edited post message", testOwner, editDate),
 			error: nil,
 		},
 	}
@@ -206,7 +219,7 @@ func TestMsgEditPost_ValidateBasic(t *testing.T) {
 
 func TestMsgEditPost_GetSignBytes(t *testing.T) {
 	actual := msgEditPost.GetSignBytes()
-	expected := `{"type":"desmos/MsgEditPost","value":{"editor":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"Edited post message","post_id":"94"}}`
+	expected := `{"type":"desmos/MsgEditPost","value":{"edit_date":"2020-02-02T15:00:00Z","editor":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"Edited post message","post_id":"94"}}`
 	assert.Equal(t, expected, string(actual))
 }
 

--- a/x/posts/internal/types/msgs_test.go
+++ b/x/posts/internal/types/msgs_test.go
@@ -99,6 +99,11 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 			error: sdk.ErrUnknownRequest("Post optional data value lengths cannot be longer than 200. key1 exceeds the limit"),
 		},
 		{
+			name:  "Future creation date returns error",
+			msg:   types.NewMsgCreatePost("future post", types.PostID(0), false, "desmos", map[string]string{}, creator, time.Now().Add(time.Hour)),
+			error: sdk.ErrUnknownRequest("Creation date cannot be in the future"),
+		},
+		{
 			name: "Valid message does not return any error",
 			msg: types.NewMsgCreatePost(
 				"Message",
@@ -168,7 +173,7 @@ func TestMsgCreatePost_GetSigners(t *testing.T) {
 // --- MsgEditPost
 // ----------------------
 
-var editDate = time.Date(2020, 2, 2, 15, 0, 0, 0, timeZone)
+var editDate = time.Date(2010, 1, 1, 15, 0, 0, 0, timeZone)
 var msgEditPost = types.NewMsgEditPost(types.PostID(94), "Edited post message", testOwner, editDate)
 
 func TestMsgEditPost_Route(t *testing.T) {
@@ -198,9 +203,24 @@ func TestMsgEditPost_ValidateBasic(t *testing.T) {
 			error: sdk.ErrInvalidAddress("Invalid editor address: "),
 		},
 		{
-			name:  "Invalid message returns error",
+			name:  "Blank message returns error",
+			msg:   types.NewMsgEditPost(types.PostID(10), " ", testOwner, editDate),
+			error: sdk.ErrUnknownRequest("Post message cannot be empty nor blank"),
+		},
+		{
+			name:  "Empty message returns error",
 			msg:   types.NewMsgEditPost(types.PostID(10), "", testOwner, editDate),
-			error: sdk.ErrUnknownRequest("Post message cannot be empty"),
+			error: sdk.ErrUnknownRequest("Post message cannot be empty nor blank"),
+		},
+		{
+			name:  "Empty edit date returns error",
+			msg:   types.NewMsgEditPost(types.PostID(10), "My new message", testOwner, time.Time{}),
+			error: sdk.ErrUnknownRequest("Invalid edit date"),
+		},
+		{
+			name:  "Future edit date returns error",
+			msg:   types.NewMsgEditPost(types.PostID(10), "My new message", testOwner, time.Now().Add(time.Hour)),
+			error: sdk.ErrUnknownRequest("Edit date cannot be in the future"),
 		},
 		{
 			name:  "Valid message returns no error",
@@ -219,7 +239,7 @@ func TestMsgEditPost_ValidateBasic(t *testing.T) {
 
 func TestMsgEditPost_GetSignBytes(t *testing.T) {
 	actual := msgEditPost.GetSignBytes()
-	expected := `{"type":"desmos/MsgEditPost","value":{"edit_date":"2020-02-02T15:00:00Z","editor":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"Edited post message","post_id":"94"}}`
+	expected := `{"type":"desmos/MsgEditPost","value":{"edit_date":"2010-01-01T15:00:00Z","editor":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns","message":"Edited post message","post_id":"94"}}`
 	assert.Equal(t, expected, string(actual))
 }
 

--- a/x/posts/internal/types/msgs_test.go
+++ b/x/posts/internal/types/msgs_test.go
@@ -68,6 +68,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 				"desmos",
 				map[string]string{},
 				creator,
+				date,
 			),
 			error: sdk.ErrUnknownRequest("Post message cannot exceed 500 characters"),
 		},

--- a/x/posts/internal/types/post.go
+++ b/x/posts/internal/types/post.go
@@ -168,8 +168,16 @@ func (p Post) Validate() error {
 		return fmt.Errorf("invalid post creation time: %s", p.Created)
 	}
 
+	if p.Created.After(time.Now()) {
+		return fmt.Errorf("post creation date cannot be in the future")
+	}
+
 	if !p.LastEdited.IsZero() && p.LastEdited.Before(p.Created) {
 		return fmt.Errorf("invalid post last edit time: %s", p.LastEdited)
+	}
+
+	if !p.LastEdited.IsZero() && p.LastEdited.After(time.Now()) {
+		return fmt.Errorf("post last edit date cannot be in the future")
 	}
 
 	if len(p.OptionalData) > MaxOptionalDataFieldsNumber {

--- a/x/posts/internal/types/post.go
+++ b/x/posts/internal/types/post.go
@@ -113,8 +113,8 @@ type Post struct {
 	PostID         PostID            `json:"id"`                      // Unique id
 	ParentID       PostID            `json:"parent_id"`               // Post of which this one is a comment
 	Message        string            `json:"message"`                 // Message contained inside the post
-	Created        time.Time         `json:"created"`                 // ISO 8601 date at which the post has been created
-	LastEdited     time.Time         `json:"last_edited"`             // ISO 8601 date at which the post has been edited the last time
+	Created        time.Time         `json:"created"`                 // RFC3339 date at which the post has been created
+	LastEdited     time.Time         `json:"last_edited"`             // RFC3339 date at which the post has been edited the last time
 	AllowsComments bool              `json:"allows_comments"`         // Tells if users can reference this PostID as the parent
 	Subspace       string            `json:"subspace"`                // Identifies the application that has posted the message
 	OptionalData   map[string]string `json:"optional_data,omitempty"` // Arbitrary data that can be used from the developers

--- a/x/posts/internal/types/post_response_test.go
+++ b/x/posts/internal/types/post_response_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/desmos-labs/desmos/x/posts/internal/types"
 
@@ -15,10 +16,13 @@ func TestPostQueryResponse_MarshalJSON(t *testing.T) {
 	liker, _ := sdk.AccAddressFromBech32("cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4")
 	otherLiker, _ := sdk.AccAddressFromBech32("cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae")
 
-	post := types.NewPost(types.PostID(10), types.PostID(0), "Post", true, "desmos", map[string]string{}, 10, postOwner)
+	timeZone, _ := time.LoadLocation("UTC")
+	date := time.Date(2020, 2, 2, 15, 0, 0, 0, timeZone)
+
+	post := types.NewPost(types.PostID(10), types.PostID(0), "Post", true, "desmos", map[string]string{}, date, postOwner)
 	likes := types.Reactions{
-		types.NewReaction("like", 11, liker),
-		types.NewReaction("like", 12, otherLiker),
+		types.NewReaction("like", liker),
+		types.NewReaction("like", otherLiker),
 	}
 	children := types.PostIDs{types.PostID(98), types.PostID(100)}
 
@@ -26,7 +30,7 @@ func TestPostQueryResponse_MarshalJSON(t *testing.T) {
 	jsonData, err := json.Marshal(&response)
 	assert.NoError(t, err)
 	assert.Equal(t,
-		`{"id":"10","parent_id":"0","message":"Post","created":"10","last_edited":"0","allows_comments":true,"subspace":"desmos","creator":"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47","reactions":[{"created":"11","owner":"cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4","value":"like"},{"created":"12","owner":"cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae","value":"like"}],"children":["98","100"]}`,
+		`{"id":"10","parent_id":"0","message":"Post","created":"2020-02-02T15:00:00Z","last_edited":"0001-01-01T00:00:00Z","allows_comments":true,"subspace":"desmos","creator":"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47","reactions":[{"owner":"cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4","value":"like"},{"owner":"cosmos15lt0mflt6j9a9auj7yl3p20xec4xvljge0zhae","value":"like"}],"children":["98","100"]}`,
 		string(jsonData),
 	)
 }

--- a/x/posts/internal/types/post_test.go
+++ b/x/posts/internal/types/post_test.go
@@ -295,7 +295,7 @@ func TestPost_Validate(t *testing.T) {
 				true,
 				"desmos",
 				map[string]string{},
-				1,
+				date,
 				owner,
 			),
 			expError: "post message cannot be longer than 500 characters",

--- a/x/posts/internal/types/post_test.go
+++ b/x/posts/internal/types/post_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/desmos-labs/desmos/x/posts/internal/types"
@@ -191,12 +192,14 @@ func TestPostIDs_AppendIfMissing(t *testing.T) {
 
 func TestPost_String(t *testing.T) {
 	owner, _ := sdk.AccAddressFromBech32("cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")
+	timeZone, _ := time.LoadLocation("UTC")
+	date := time.Date(2020, 1, 1, 12, 00, 00, 000, timeZone)
 	post := types.Post{
 		PostID:         types.PostID(19),
 		ParentID:       types.PostID(1),
 		Message:        "My post message",
-		Created:        sdk.NewInt(98),
-		LastEdited:     sdk.NewInt(105),
+		Created:        date,
+		LastEdited:     date.AddDate(0, 0, 1),
 		AllowsComments: true,
 		Subspace:       "desmos",
 		OptionalData:   map[string]string{},
@@ -204,47 +207,51 @@ func TestPost_String(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		`{"id":"19","parent_id":"1","message":"My post message","created":"98","last_edited":"105","allows_comments":true,"subspace":"desmos","creator":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"}`,
+		`{"id":"19","parent_id":"1","message":"My post message","created":"2020-01-01T12:00:00Z","last_edited":"2020-01-02T12:00:00Z","allows_comments":true,"subspace":"desmos","creator":"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"}`,
 		post.String(),
 	)
 }
 
 func TestPost_Validate(t *testing.T) {
 	owner, _ := sdk.AccAddressFromBech32("cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")
+
+	timeZone, _ := time.LoadLocation("UTC")
+	date := time.Date(2020, 1, 1, 12, 00, 00, 000, timeZone)
+
 	tests := []struct {
 		post     types.Post
 		expError string
 	}{
 		{
-			post:     types.NewPost(types.PostID(0), types.PostID(0), "Message", true, "Desmos", map[string]string{}, 10, owner),
+			post:     types.NewPost(types.PostID(0), types.PostID(0), "Message", true, "Desmos", map[string]string{}, date, owner),
 			expError: "invalid post id: 0",
 		},
 		{
-			post:     types.NewPost(types.PostID(1), types.PostID(0), "", true, "Desmos", map[string]string{}, 10, nil),
+			post:     types.NewPost(types.PostID(1), types.PostID(0), "", true, "Desmos", map[string]string{}, date, nil),
 			expError: "invalid post owner: ",
 		},
 		{
-			post:     types.NewPost(types.PostID(1), types.PostID(0), "", true, "Desmos", map[string]string{}, 10, owner),
+			post:     types.NewPost(types.PostID(1), types.PostID(0), "", true, "Desmos", map[string]string{}, date, owner),
 			expError: "post message must be non empty and non blank",
 		},
 		{
-			post:     types.NewPost(types.PostID(1), types.PostID(0), " ", true, "Desmos", map[string]string{}, 10, owner),
+			post:     types.NewPost(types.PostID(1), types.PostID(0), " ", true, "Desmos", map[string]string{}, date, owner),
 			expError: "post message must be non empty and non blank",
 		},
 		{
-			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, "Desmos", map[string]string{}, 0, owner),
-			expError: "invalid post creation block height: 0",
+			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, "Desmos", map[string]string{}, time.Time{}, owner),
+			expError: "invalid post creation time: 0001-01-01 00:00:00 +0000 UTC",
 		},
 		{
-			post:     types.Post{PostID: types.PostID(19), Creator: owner, Message: "Message", Subspace: "desmos", Created: sdk.NewInt(10), LastEdited: sdk.NewInt(9)},
-			expError: "invalid post last edit block height: 9",
+			post:     types.Post{PostID: types.PostID(19), Creator: owner, Message: "Message", Subspace: "desmos", Created: date, LastEdited: date.AddDate(0, 0, -1)},
+			expError: "invalid post last edit time: 2019-12-31 12:00:00 +0000 UTC",
 		},
 		{
-			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, "", map[string]string{}, 1, owner),
+			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, "", map[string]string{}, date, owner),
 			expError: "post subspace must be non empty and non blank",
 		},
 		{
-			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, " ", map[string]string{}, 1, owner),
+			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, " ", map[string]string{}, date, owner),
 			expError: "post subspace must be non empty and non blank",
 		},
 		{
@@ -267,7 +274,7 @@ func TestPost_Validate(t *testing.T) {
 					"key10": "value",
 					"key11": "value",
 				},
-				1,
+				date,
 				owner,
 			),
 			expError: "post optional data cannot contain more than 10 key-value pairs",
@@ -280,15 +287,17 @@ func TestPost_Validate(t *testing.T) {
 				true,
 				"desmos",
 				map[string]string{
-					"key1": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque euismod, mi at commodo efficitur, quam sapien congue enim, ut porttitor lacus tellus vitae turpis. Vivamus aliquam sem eget neque metus.",
+					"key1": `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque euismod, mi at commodo 
+							efficitur, quam sapien congue enim, ut porttitor lacus tellus vitae turpis. Vivamus aliquam 
+							sem eget neque metus.`,
 				},
-				1,
+				date,
 				owner,
 			),
 			expError: "post optional data values cannot exceed 200 characters. key1 of post with id 1 is longer than this",
 		},
 		{
-			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, "Desmos", map[string]string{}, 1, owner),
+			post:     types.NewPost(types.PostID(1), types.PostID(0), "Message", true, "Desmos", map[string]string{}, date, owner),
 			expError: "",
 		},
 	}
@@ -309,6 +318,9 @@ func TestPost_Equals(t *testing.T) {
 	owner, _ := sdk.AccAddressFromBech32("cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")
 	otherOwner, _ := sdk.AccAddressFromBech32("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
 
+	timeZone, _ := time.LoadLocation("UTC")
+	date := time.Date(2020, 1, 1, 12, 00, 00, 000, timeZone)
+
 	tests := []struct {
 		name      string
 		first     types.Post
@@ -321,8 +333,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -332,8 +344,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(10),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -347,8 +359,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -358,8 +370,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(10),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -373,8 +385,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -384,8 +396,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "Another post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -399,8 +411,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -410,8 +422,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(15),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date.AddDate(0, 0, 1),
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -425,8 +437,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -436,8 +448,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(13),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 2),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -451,8 +463,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -462,8 +474,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: false,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -477,8 +489,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos-1",
 				OptionalData:   map[string]string{},
@@ -488,8 +500,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos-2",
 				OptionalData:   map[string]string{},
@@ -503,8 +515,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData: map[string]string{
@@ -516,8 +528,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData: map[string]string{
@@ -533,8 +545,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -544,8 +556,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -559,8 +571,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -570,8 +582,8 @@ func TestPost_Equals(t *testing.T) {
 				PostID:         types.PostID(19),
 				ParentID:       types.PostID(1),
 				Message:        "My post message",
-				Created:        sdk.NewInt(98),
-				LastEdited:     sdk.NewInt(105),
+				Created:        date,
+				LastEdited:     date.AddDate(0, 0, 1),
 				AllowsComments: true,
 				Subspace:       "desmos",
 				OptionalData:   map[string]string{},
@@ -593,6 +605,9 @@ func TestPost_Equals(t *testing.T) {
 // --- Posts
 // -----------
 func TestPosts_Equals(t *testing.T) {
+	timeZone, _ := time.LoadLocation("UTC")
+	date := time.Date(2020, 1, 1, 12, 0, 00, 000, timeZone)
+
 	tests := []struct {
 		name      string
 		first     types.Posts
@@ -608,35 +623,35 @@ func TestPosts_Equals(t *testing.T) {
 		{
 			name: "List of different lengths are not equals",
 			first: types.Posts{
-				types.Post{PostID: types.PostID(0), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
+				types.Post{PostID: types.PostID(0), Created: date, LastEdited: date.AddDate(0, 0, 1)},
 			},
 			second: types.Posts{
-				types.Post{PostID: types.PostID(0), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
-				types.Post{PostID: types.PostID(1), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
+				types.Post{PostID: types.PostID(0), Created: date, LastEdited: date.AddDate(0, 0, 1)},
+				types.Post{PostID: types.PostID(1), Created: date, LastEdited: date.AddDate(0, 0, 1)},
 			},
 			expEquals: false,
 		},
 		{
 			name: "Same lists but in different orders",
 			first: types.Posts{
-				types.Post{PostID: types.PostID(0), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
-				types.Post{PostID: types.PostID(1), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
+				types.Post{PostID: types.PostID(0), Created: date, LastEdited: date.AddDate(0, 0, 1)},
+				types.Post{PostID: types.PostID(1), Created: date, LastEdited: date.AddDate(0, 0, 1)},
 			},
 			second: types.Posts{
-				types.Post{PostID: types.PostID(1), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
-				types.Post{PostID: types.PostID(0), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
+				types.Post{PostID: types.PostID(1), Created: date, LastEdited: date.AddDate(0, 0, 1)},
+				types.Post{PostID: types.PostID(0), Created: date, LastEdited: date.AddDate(0, 0, 1)},
 			},
 			expEquals: false,
 		},
 		{
 			name: "Same lists are equals",
 			first: types.Posts{
-				types.Post{PostID: types.PostID(0), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
-				types.Post{PostID: types.PostID(1), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
+				types.Post{PostID: types.PostID(0), Created: date, LastEdited: date.AddDate(0, 0, 1)},
+				types.Post{PostID: types.PostID(1), Created: date, LastEdited: date.AddDate(0, 0, 1)},
 			},
 			second: types.Posts{
-				types.Post{PostID: types.PostID(0), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
-				types.Post{PostID: types.PostID(1), Created: sdk.ZeroInt(), LastEdited: sdk.ZeroInt()},
+				types.Post{PostID: types.PostID(0), Created: date, LastEdited: date.AddDate(0, 0, 1)},
+				types.Post{PostID: types.PostID(1), Created: date, LastEdited: date.AddDate(0, 0, 1)},
 			},
 			expEquals: true,
 		},
@@ -653,9 +668,13 @@ func TestPosts_Equals(t *testing.T) {
 func TestPosts_String(t *testing.T) {
 	owner1, _ := sdk.AccAddressFromBech32("cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")
 	owner2, _ := sdk.AccAddressFromBech32("cosmos1r2plnngkwnahajl3d2a7fvzcsxf6djlt380f3l")
+
+	timeZone, _ := time.LoadLocation("UTC")
+	date := time.Date(2020, 1, 1, 12, 0, 00, 000, timeZone)
+
 	posts := types.Posts{
-		types.NewPost(types.PostID(1), types.PostID(10), "Post 1", false, "external-ref-1", map[string]string{}, 0, owner1),
-		types.NewPost(types.PostID(2), types.PostID(10), "Post 2", false, "external-ref-1", map[string]string{}, 0, owner2),
+		types.NewPost(types.PostID(1), types.PostID(10), "Post 1", false, "external-ref-1", map[string]string{}, date, owner1),
+		types.NewPost(types.PostID(2), types.PostID(10), "Post 2", false, "external-ref-1", map[string]string{}, date, owner2),
 	}
 
 	expected := `ID - [Creator] Message

--- a/x/posts/internal/types/post_test.go
+++ b/x/posts/internal/types/post_test.go
@@ -255,6 +255,33 @@ func TestPost_Validate(t *testing.T) {
 			expError: "post subspace must be non empty and non blank",
 		},
 		{
+			post: types.Post{
+				PostID:         types.PostID(1),
+				ParentID:       types.PostID(0),
+				Message:        "Message",
+				AllowsComments: true,
+				Subspace:       "desmos",
+				OptionalData:   map[string]string{},
+				Created:        time.Now().Add(time.Hour),
+				Creator:        owner,
+			},
+			expError: "post creation date cannot be in the future",
+		},
+		{
+			post: types.Post{
+				PostID:         types.PostID(1),
+				ParentID:       types.PostID(0),
+				Message:        "Message",
+				AllowsComments: true,
+				Subspace:       "desmos",
+				OptionalData:   map[string]string{},
+				Created:        time.Now(),
+				LastEdited:     time.Now().Add(time.Hour),
+				Creator:        owner,
+			},
+			expError: "post last edit date cannot be in the future",
+		},
+		{
 			post: types.NewPost(
 				types.PostID(1),
 				types.PostID(0),

--- a/x/posts/internal/types/querier.go
+++ b/x/posts/internal/types/querier.go
@@ -1,6 +1,10 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 // QueryPostsParams Params for query 'custom/posts/posts'
 type QueryPostsParams struct {
@@ -8,7 +12,7 @@ type QueryPostsParams struct {
 	Limit int
 
 	ParentID       *PostID
-	CreationTime   sdk.Int
+	CreationTime   *time.Time
 	AllowsComments *bool
 	Subspace       string
 	Creator        sdk.AccAddress
@@ -20,7 +24,7 @@ func DefaultQueryPostsParams(page, limit int) QueryPostsParams {
 		Limit: limit,
 
 		ParentID:       nil,
-		CreationTime:   sdk.NewInt(-1),
+		CreationTime:   nil,
 		AllowsComments: nil,
 		Subspace:       "",
 		Creator:        nil,
@@ -29,14 +33,14 @@ func DefaultQueryPostsParams(page, limit int) QueryPostsParams {
 
 // NewQueryPostsParams creates a new instance of QueryPostsParams
 func NewQueryPostsParams(page, limit int,
-	parentID *PostID, creationTime sdk.Int, allowsComments bool, subspace string, owner sdk.AccAddress,
+	parentID *PostID, creationTime time.Time, allowsComments bool, subspace string, owner sdk.AccAddress,
 ) QueryPostsParams {
 	return QueryPostsParams{
 		Page:  page,
 		Limit: limit,
 
 		ParentID:       parentID,
-		CreationTime:   creationTime,
+		CreationTime:   &creationTime,
 		AllowsComments: &allowsComments,
 		Subspace:       subspace,
 		Creator:        owner,

--- a/x/posts/internal/types/reaction.go
+++ b/x/posts/internal/types/reaction.go
@@ -14,17 +14,15 @@ import (
 
 // Reaction is a struct of a user reaction to a post
 type Reaction struct {
-	Created sdk.Int        `json:"created"` // Block height at which the reaction was created
-	Owner   sdk.AccAddress `json:"owner"`   // User that has created the reaction
-	Value   string         `json:"value"`   // Reaction of the reaction
+	Owner sdk.AccAddress `json:"owner"` // User that has created the reaction
+	Value string         `json:"value"` // Reaction of the reaction
 }
 
 // NewReaction returns a new Reaction
-func NewReaction(value string, created int64, owner sdk.AccAddress) Reaction {
+func NewReaction(value string, owner sdk.AccAddress) Reaction {
 	return Reaction{
-		Value:   value,
-		Created: sdk.NewInt(created),
-		Owner:   owner,
+		Value: value,
+		Owner: owner,
 	}
 }
 
@@ -43,10 +41,6 @@ func (reaction Reaction) Validate() error {
 		return fmt.Errorf("invalid reaction owner: %s", reaction.Owner)
 	}
 
-	if reaction.Created.Equal(sdk.ZeroInt()) {
-		return fmt.Errorf("invalid reaction creation block height: %s", reaction.Created)
-	}
-
 	if len(strings.TrimSpace(reaction.Value)) == 0 {
 		return fmt.Errorf("reaction value cannot empty or blank")
 	}
@@ -57,7 +51,6 @@ func (reaction Reaction) Validate() error {
 // Equals returns true if reaction and other contain the same data
 func (reaction Reaction) Equals(other Reaction) bool {
 	return reaction.Value == other.Value &&
-		reaction.Created == other.Created &&
 		reaction.Owner.Equals(other.Owner)
 }
 

--- a/x/posts/internal/types/reaction_test.go
+++ b/x/posts/internal/types/reaction_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestReaction_String(t *testing.T) {
 	user, _ := sdk.AccAddressFromBech32("cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4")
-	reaction := types.NewReaction("reaction", 1, user)
-	assert.Equal(t, `{"created":"1","owner":"cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4","value":"reaction"}`, reaction.String())
+	reaction := types.NewReaction("reaction", user)
+	assert.Equal(t, `{"owner":"cosmos1s3nh6tafl4amaxkke9kdejhp09lk93g9ev39r4","value":"reaction"}`, reaction.String())
 }
 
 func TestReaction_Validate(t *testing.T) {
@@ -24,18 +24,13 @@ func TestReaction_Validate(t *testing.T) {
 	}{
 		{
 			name:     "Valid reaction returns no error",
-			reaction: types.NewReaction("reaction", 10, user),
+			reaction: types.NewReaction("reaction", user),
 			error:    nil,
 		},
 		{
 			name:     "Missing owner returns error",
-			reaction: types.NewReaction("reaction", 10, nil),
+			reaction: types.NewReaction("reaction", nil),
 			error:    errors.New("invalid reaction owner: "),
-		},
-		{
-			name:     "Zero creation time returns error",
-			reaction: types.NewReaction("reaction", 0, user),
-			error:    errors.New("invalid reaction creation block height: 0"),
 		},
 	}
 
@@ -57,21 +52,16 @@ func TestReaction_Equals(t *testing.T) {
 		shouldBeEqual bool
 	}{
 		{
-			name:          "Returns false with different creation time",
-			first:         types.NewReaction("reaction", 5, user),
-			second:        types.NewReaction("reaction", 6, user),
-			shouldBeEqual: false,
-		},
-		{
 			name:          "Returns false with different user",
-			first:         types.NewReaction("reaction", 10, user),
-			second:        types.NewReaction("reaction", 10, otherLiker),
+			first:         types.NewReaction("reaction", user),
+			second:        types.NewReaction("reaction", otherLiker),
 			shouldBeEqual: false,
 		},
 		{
-			name:   "Returns true with the same data",
-			first:  types.NewReaction("reaction", 10, user),
-			second: types.NewReaction("reaction", 10, user),
+			name:          "Returns true with the same data",
+			first:         types.NewReaction("reaction", user),
+			second:        types.NewReaction("reaction", user),
+			shouldBeEqual: true,
 		},
 	}
 
@@ -96,18 +86,18 @@ func TestReactions_AppendIfMissing(t *testing.T) {
 		{
 			name:      "New reaction is appended properly to empty list",
 			reactions: types.Reactions{},
-			newLike:   types.NewReaction("reaction", 10, user),
-			expLikes:  types.Reactions{types.NewReaction("reaction", 10, user)},
+			newLike:   types.NewReaction("reaction", user),
+			expLikes:  types.Reactions{types.NewReaction("reaction", user)},
 			expAppend: true,
 		},
 		{
 			name:      "New reaction is appended properly to existing list",
-			reactions: types.Reactions{types.NewReaction("reaction", 1, user)},
-			newLike:   types.NewReaction("reaction", 10, otherLiker),
+			reactions: types.Reactions{types.NewReaction("reaction", user)},
+			newLike:   types.NewReaction("reaction", otherLiker),
 			expAppend: true,
 			expLikes: types.Reactions{
-				types.NewReaction("reaction", 1, user),
-				types.NewReaction("reaction", 10, otherLiker),
+				types.NewReaction("reaction", user),
+				types.NewReaction("reaction", otherLiker),
 			},
 		},
 	}
@@ -134,7 +124,7 @@ func TestReactions_ContainsOwnerLike(t *testing.T) {
 	}{
 		{
 			name:        "Non-empty list returns true with valid address",
-			reactions:   types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions:   types.Reactions{types.NewReaction("reaction", user)},
 			owner:       user,
 			value:       "reaction",
 			expContains: true,
@@ -148,14 +138,14 @@ func TestReactions_ContainsOwnerLike(t *testing.T) {
 		},
 		{
 			name:        "Non-empty list returns false with not found address",
-			reactions:   types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions:   types.Reactions{types.NewReaction("reaction", user)},
 			owner:       otherLiker,
 			value:       "reaction",
 			expContains: false,
 		},
 		{
 			name:        "Non-empty list returns false with not found value",
-			reactions:   types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions:   types.Reactions{types.NewReaction("reaction", user)},
 			owner:       user,
 			value:       "reaction-2",
 			expContains: false,
@@ -182,7 +172,7 @@ func TestReactions_IndexOfByUserAndValue(t *testing.T) {
 	}{
 		{
 			name:      "Non-empty list returns proper index with valid value",
-			reactions: types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions: types.Reactions{types.NewReaction("reaction", user)},
 			owner:     user,
 			value:     "reaction",
 			expIndex:  0,
@@ -196,14 +186,14 @@ func TestReactions_IndexOfByUserAndValue(t *testing.T) {
 		},
 		{
 			name:      "Non-empty list returns -1 with not found address",
-			reactions: types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions: types.Reactions{types.NewReaction("reaction", user)},
 			owner:     otherLiker,
 			value:     "reaction",
 			expIndex:  -1,
 		},
 		{
 			name:      "Non-empty list returns -1 with not found value",
-			reactions: types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions: types.Reactions{types.NewReaction("reaction", user)},
 			owner:     otherLiker,
 			value:     "reaction-2",
 			expIndex:  -1,
@@ -231,7 +221,7 @@ func TestReactions_RemoveReaction(t *testing.T) {
 	}{
 		{
 			name:      "Reaction is removed from non-empty list",
-			reactions: types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions: types.Reactions{types.NewReaction("reaction", user)},
 			owner:     user,
 			value:     "reaction",
 			expResult: types.Reactions{},
@@ -247,18 +237,18 @@ func TestReactions_RemoveReaction(t *testing.T) {
 		},
 		{
 			name:      "Non-empty list with not found address is not edited",
-			reactions: types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions: types.Reactions{types.NewReaction("reaction", user)},
 			owner:     otherLiker,
 			value:     "reaction",
-			expResult: types.Reactions{types.NewReaction("reaction", 1, user)},
+			expResult: types.Reactions{types.NewReaction("reaction", user)},
 			expEdited: false,
 		},
 		{
 			name:      "Non-empty list with not found value is not edited",
-			reactions: types.Reactions{types.NewReaction("reaction", 1, user)},
+			reactions: types.Reactions{types.NewReaction("reaction", user)},
 			owner:     otherLiker,
 			value:     "reaction-2",
-			expResult: types.Reactions{types.NewReaction("reaction", 1, user)},
+			expResult: types.Reactions{types.NewReaction("reaction", user)},
 			expEdited: false,
 		},
 	}

--- a/x/posts/legacy/v0.2.0/migrate.go
+++ b/x/posts/legacy/v0.2.0/migrate.go
@@ -2,6 +2,7 @@ package v0_2_0
 
 import (
 	"strings"
+	"time"
 
 	v010posts "github.com/desmos-labs/desmos/x/posts/legacy/v0.1.0"
 )
@@ -10,9 +11,9 @@ import (
 // genesis state. This migration changes the data that are saved for each post
 // moving the external reference into the arbitrary data map and adding the new
 // subspace field
-func Migrate(oldGenState v010posts.GenesisState) GenesisState {
+func Migrate(oldGenState v010posts.GenesisState, genesisTime time.Time, blockInterval int) GenesisState {
 	return GenesisState{
-		Posts:     migratePosts(oldGenState.Posts),
+		Posts:     migratePosts(oldGenState.Posts, genesisTime, blockInterval),
 		Reactions: migrateLikes(oldGenState.Likes),
 	}
 }
@@ -22,7 +23,7 @@ func Migrate(oldGenState v010posts.GenesisState) GenesisState {
 // - Each external_reference Post value (if not empty or blank) is put inside the optional_data map using
 //   external_reference as the value's associated key
 // - Post subspaces are left empty so that they can be properly set after the migration has been completed
-func migratePosts(posts []v010posts.Post) []Post {
+func migratePosts(posts []v010posts.Post, genesisTime time.Time, blockInterval int) []Post {
 	migratedPosts := make([]Post, len(posts))
 
 	// Migrate the posts
@@ -33,16 +34,23 @@ func migratePosts(posts []v010posts.Post) []Post {
 			optionalData["external_reference"] = oldPost.ExternalReference
 		}
 
+		created := genesisTime.Add(time.Second * time.Duration(oldPost.Created.Int64()*int64(blockInterval)))
+
+		lastEdited := time.Time{}
+		if !oldPost.LastEdited.IsZero() {
+			lastEdited = genesisTime.Add(time.Second * time.Duration(oldPost.LastEdited.Int64()*int64(blockInterval)))
+		}
+
 		migratedPosts[index] = Post{
 			PostID:         PostID(oldPost.PostID),
 			ParentID:       PostID(oldPost.ParentID),
 			Message:        oldPost.Message,
-			Created:        oldPost.Created,
-			LastEdited:     oldPost.LastEdited,
+			Created:        created,
+			LastEdited:     lastEdited,
 			AllowsComments: oldPost.AllowsComments,
 			Subspace:       "",
 			OptionalData:   optionalData,
-			Owner:          oldPost.Owner,
+			Creator:        oldPost.Owner,
 		}
 	}
 
@@ -61,9 +69,8 @@ func migrateLikes(likes map[string][]v010posts.Like) map[string][]Reaction {
 		reactions := make([]Reaction, len(value))
 		for index, like := range value {
 			reactions[index] = Reaction{
-				Created: like.Created,
-				Owner:   like.Owner,
-				Value:   "like",
+				Owner: like.Owner,
+				Value: "like",
 			}
 		}
 

--- a/x/posts/legacy/v0.2.0/migrate.go
+++ b/x/posts/legacy/v0.2.0/migrate.go
@@ -34,8 +34,8 @@ func migratePosts(posts []v010posts.Post, genesisTime time.Time, blockInterval i
 			optionalData["external_reference"] = oldPost.ExternalReference
 		}
 
+		// Get the creation and last edit times in timestamps
 		created := genesisTime.Add(time.Second * time.Duration(oldPost.Created.Int64()*int64(blockInterval)))
-
 		lastEdited := time.Time{}
 		if !oldPost.LastEdited.IsZero() {
 			lastEdited = genesisTime.Add(time.Second * time.Duration(oldPost.LastEdited.Int64()*int64(blockInterval)))

--- a/x/posts/legacy/v0.2.0/types.go
+++ b/x/posts/legacy/v0.2.0/types.go
@@ -1,6 +1,10 @@
 package v0_2_0
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 const (
 	ModuleName = "posts"
@@ -20,17 +24,16 @@ type Post struct {
 	PostID         PostID            `json:"id"`                      // Unique id
 	ParentID       PostID            `json:"parent_id"`               // Post of which this one is a comment
 	Message        string            `json:"message"`                 // Message contained inside the post
-	Created        sdk.Int           `json:"created"`                 // Block height at which the post has been created
-	LastEdited     sdk.Int           `json:"last_edited"`             // Block height at which the post has been edited the last time
+	Created        time.Time         `json:"created"`                 // RFC3339 date at which the post has been created
+	LastEdited     time.Time         `json:"last_edited"`             // RFC3339 date at which the post has been edited the last time
 	AllowsComments bool              `json:"allows_comments"`         // Tells if users can reference this PostID as the parent
 	Subspace       string            `json:"subspace"`                // Identifies the application that has posted the message
 	OptionalData   map[string]string `json:"optional_data,omitempty"` // Arbitrary data that can be used from the developers
-	Owner          sdk.AccAddress    `json:"owner"`                   // Creator of the Post
+	Creator        sdk.AccAddress    `json:"creator"`                 // Creator of the Post
 }
 
 // Reaction is a struct of a user reaction to a post
 type Reaction struct {
-	Created sdk.Int        `json:"created"` // Block height at which the reaction was created
-	Owner   sdk.AccAddress `json:"owner"`   // User that has created the reaction
-	Value   string         `json:"value"`   // Reaction of the reaction
+	Owner sdk.AccAddress `json:"owner"` // User that has created the reaction
+	Value string         `json:"value"` // Reaction of the reaction
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR replaces all the usages of block heights inside the Post module with timestamps in RFC3339 format (using `time.Time`). Closes #62.

### TODO: 
- [x] Modify the migrate command to accept the genesis time and block interval that should be considered when converting posts creation time from using block heights to using timestamps

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests.
- [x] Added an entry to the `CHANGELOG.md` file.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
