### PR TITLE
Allow empty messages with non-empty polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Changes
 - Implemented invariants for posts and profile modules (#90)
 - Added YAML support for types (#124)
+- Allow for empty message posts when they contain a poll (#148)
 
 # Version 0.4.0
 ## Changes

--- a/docs/types/reaction.md
+++ b/docs/types/reaction.md
@@ -17,7 +17,7 @@ The `ShortCode` identifies the actual reaction short code.
 Short codes are codes used on various websites to speed up reaction insertion using a keyboard.
 These begin and end with a colon, and contain the literal name of the reaction itself. 
 For example, it can look something like `:emoji-shortcode:`.
-When registering a new reaction, the shot code must be validated by the following regEx: `:[a-z]([a-z\d_])*:`. 
+When registering a new reaction, the shot code must be validated by the following regEx: `:[a-z0-9+-]([a-z0-9\d_-])*:`. 
 [Here](https://www.webfx.com/tools/emoji-cheat-sheet/) the list of all available short codes.
 
 ### `Value`

--- a/x/posts/client/cli/tx.go
+++ b/x/posts/client/cli/tx.go
@@ -91,6 +91,8 @@ If you want to add a poll to your post you need to specify it through two flags:
   2. --poll-answer, which accepts a slice of answers that will be provided to the users once they want to take part in the poll votations.	
      Each answer should be identified by the text of the answer itself.
 
+If polls are provided, the post could be created even without any message as following:
+
 E.g.
 %s tx posts create "4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e" "Post with poll" true \
 	--poll-details "question=Which dog do you prefer?,multiple-answers=false,allows-answer-edits=true,end-date=2020-01-01T15:00:00.000Z" \

--- a/x/posts/client/cli/tx.go
+++ b/x/posts/client/cli/tx.go
@@ -91,7 +91,7 @@ If you want to add a poll to your post you need to specify it through two flags:
   2. --poll-answer, which accepts a slice of answers that will be provided to the users once they want to take part in the poll votations.	
      Each answer should be identified by the text of the answer itself.
 
-If a poll is provided, the post can be created even without specifying any message as following:
+If a poll is provided, the post can be created even without specifying any message as follows:
 
 E.g.
 %s tx posts create "4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e" "Post with poll" true \

--- a/x/posts/internal/types/msgs.go
+++ b/x/posts/internal/types/msgs.go
@@ -56,8 +56,8 @@ func (msg MsgCreatePost) ValidateBasic() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, fmt.Sprintf("Invalid creator address: %s", msg.Creator))
 	}
 
-	if len(strings.TrimSpace(msg.Message)) == 0 && len(msg.Medias) == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Post message or medias are required and cannot be both blank or empty")
+	if len(strings.TrimSpace(msg.Message)) == 0 && len(msg.Medias) == 0 && msg.PollData == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Post message, medias or poll are required and cannot be all blank or empty")
 	}
 
 	if len(msg.Message) > MaxPostMessageLength {

--- a/x/posts/internal/types/msgs_test.go
+++ b/x/posts/internal/types/msgs_test.go
@@ -76,7 +76,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 			error: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "Invalid creator address: "),
 		},
 		{
-			name: "Empty message returns error if medias and message are empty",
+			name: "Empty message returns error if medias, poll data and message are empty",
 			msg: types.NewMsgCreatePost(
 				"",
 				"",
@@ -86,9 +86,9 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 				creator,
 				date,
 				nil,
-				msgCreatePost.PollData,
+				nil,
 			),
-			error: sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Post message or medias are required and cannot be both blank or empty"),
+			error: sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Post message, medias or poll are required and cannot be all blank or empty"),
 		},
 		{
 			name: "Non-empty message returns no error if medias are empty",
@@ -132,6 +132,36 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 				date,
 				msgCreatePost.Medias,
 				msgCreatePost.PollData,
+			),
+			error: nil,
+		},
+		{
+			name: "Empty message returns no error if poll isn't empty",
+			msg: types.NewMsgCreatePost(
+				"",
+				"",
+				false,
+				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
+				map[string]string{},
+				creator,
+				date,
+				nil,
+				msgCreatePost.PollData,
+			),
+			error: nil,
+		},
+		{
+			name: "Non-empty message returns no error if poll is empty",
+			msg: types.NewMsgCreatePost(
+				"message",
+				"",
+				false,
+				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
+				map[string]string{},
+				creator,
+				date,
+				nil,
+				nil,
 			),
 			error: nil,
 		},
@@ -317,7 +347,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 			error: nil,
 		},
 		{
-			name: "Message with empty medias and non-empty message returns no error",
+			name: "Message with empty medias non-empty poll and non-empty message returns no error",
 			msg: types.NewMsgCreatePost(
 				"My message",
 				"",
@@ -332,7 +362,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 			error: nil,
 		},
 		{
-			name: "Message with non-empty medias and non-empty message returns no error",
+			name: "Message with non-empty medias, non-empty poll and non-empty message returns no error",
 			msg: types.NewMsgCreatePost(
 				"My message",
 				"",
@@ -347,7 +377,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 			error: nil,
 		},
 		{
-			name: "Message with non-empty medias and empty message returns no error",
+			name: "Message with non-empty medias, non empty poll and empty message returns no error",
 			msg: types.NewMsgCreatePost(
 				"",
 				"",
@@ -362,7 +392,7 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 			error: nil,
 		},
 		{
-			name: "Message with empty medias and empty message returns error",
+			name: "Message with empty medias, non empty poll and empty message returns no error",
 			msg: types.NewMsgCreatePost(
 				"",
 				"",
@@ -374,10 +404,10 @@ func TestMsgCreatePost_ValidateBasic(t *testing.T) {
 				nil,
 				msgCreatePost.PollData,
 			),
-			error: sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "Post message or medias are required and cannot be both blank or empty"),
+			error: nil,
 		},
 		{
-			name: "Message with empty poll returns no error",
+			name: "Message with empty poll, non-empty medias and non empty message returns no error",
 			msg: types.NewMsgCreatePost(
 				"My message",
 				"",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR allows the creation of posts with empty message if a poll inside them is specified.
Closes #148.

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit tests.
- [x] Wrote integration tests (simulation & CLI). 
- [x] Updated the documentation. 
- [x] Added an entry to the `CHANGELOG.md` file.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
