### PR TITLE
Fixed typo in cli command tx posts create

### DIFF
--- a/x/magpie/alias.go
+++ b/x/magpie/alias.go
@@ -27,6 +27,7 @@ const (
 
 var (
 	// functions aliases
+
 	RandomizedGenState       = simulation.RandomizedGenState
 	WeightedOperations       = simulation.WeightedOperations
 	SimulateMsgCreateSession = simulation.SimulateMsgCreateSession
@@ -45,6 +46,7 @@ var (
 	NewQuerier               = keeper.NewQuerier
 
 	// variable aliases
+
 	RandomNamespaces      = simulation.RandomNamespaces
 	SessionLengthKey      = types.SessionLengthKey
 	LastSessionIDStoreKey = types.LastSessionIDStoreKey

--- a/x/posts/alias.go
+++ b/x/posts/alias.go
@@ -66,6 +66,7 @@ const (
 
 var (
 	// functions aliases
+
 	NewPostMedia                     = common.NewPostMedia
 	ValidateURI                      = common.ValidateURI
 	NewPostMedias                    = common.NewPostMedias
@@ -139,6 +140,7 @@ var (
 	RegisterModelsCodec              = models.RegisterModelsCodec
 
 	// variable aliases
+
 	RandomMimeTypes          = simulation.RandomMimeTypes
 	RandomHosts              = simulation.RandomHosts
 	ModuleCdc                = types.ModuleCdc

--- a/x/posts/client/cli/tx.go
+++ b/x/posts/client/cli/tx.go
@@ -96,7 +96,7 @@ If you want to add a poll to your post you need to specify it through two flags:
 If a poll is provided, the post can be created even without specifying any message as follows:
 
 E.g.
-%s tx posts create "4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e" "Post with poll" true \
+%s tx posts create "4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e" "Post with poll" \
 	--poll-details "question=Which dog do you prefer?,multiple-answers=false,allows-answer-edits=true,end-date=2020-01-01T15:00:00.000Z" \
 	--poll-answer "Beagle" \
 	--poll-answer "Pug" \

--- a/x/posts/internal/types/alias.go
+++ b/x/posts/internal/types/alias.go
@@ -38,6 +38,7 @@ const (
 
 var (
 	// functions aliases
+
 	RegisterModelsCodec      = models.RegisterModelsCodec
 	PostStoreKey             = models.PostStoreKey
 	PostCommentsStoreKey     = models.PostCommentsStoreKey
@@ -73,6 +74,7 @@ var (
 	NewMsgRegisterReaction   = msgs.NewMsgRegisterReaction
 
 	// variable aliases
+
 	ModelsCdc                = models.ModelsCdc
 	Sha256RegEx              = common.Sha256RegEx
 	HashtagRegEx             = common.HashtagRegEx

--- a/x/posts/internal/types/models/alias.go
+++ b/x/posts/internal/types/models/alias.go
@@ -36,6 +36,7 @@ const (
 
 var (
 	// functions aliases
+
 	NewPostMedia      = common.NewPostMedia
 	ValidateURI       = common.ValidateURI
 	NewPostMedias     = common.NewPostMedias
@@ -53,6 +54,7 @@ var (
 	NewReactions      = reactions.NewReactions
 
 	// variable aliases
+
 	Sha256RegEx              = common.Sha256RegEx
 	HashtagRegEx             = common.HashtagRegEx
 	ShortCodeRegEx           = common.ShortCodeRegEx

--- a/x/profile/alias.go
+++ b/x/profile/alias.go
@@ -37,6 +37,7 @@ const (
 
 var (
 	// functions aliases
+
 	NewHandler               = keeper.NewHandler
 	GetEditedProfile         = keeper.GetEditedProfile
 	RegisterInvariants       = keeper.RegisterInvariants
@@ -73,6 +74,7 @@ var (
 	RegisterCodec            = types.RegisterCodec
 
 	// variable aliases
+
 	TxHashRegEx        = types.TxHashRegEx
 	URIRegEx           = types.URIRegEx
 	ProfileStorePrefix = types.ProfileStorePrefix
@@ -82,7 +84,6 @@ var (
 
 type (
 	Keeper           = keeper.Keeper
-	ProfileData      = simulation.ProfileData
 	GenesisState     = types.GenesisState
 	MsgCreateProfile = types.MsgCreateProfile
 	MsgEditProfile   = types.MsgEditProfile


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes the typo inside the cli command `posts create`.
Closes #156.
## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [ ] Wrote integration tests (simulation & CLI). 
- [ ] Updated the documentation. 
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
