### PR TITLE
Profiles save command fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Changed the data stored inside the profile objects (#193)
 - Renamed the `profile_cov` field of `MsgSaveProfile` to `cover_picture`
 - Rename the `profile_pic` field of `MsgSaveProfile` to `profile_picture`
-- Moved profile module constants to chain parameters (#171) 
+- Moved profile module constants to chain parameters (#171)
 
 ## Bug fixes
 - Fixed a bug inside the `Equals` method of the `Pictures` object 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 - Changed the data stored inside the profile objects (#193)
 - Renamed the `profile_cov` field of `MsgSaveProfile` to `cover_picture`
 - Rename the `profile_pic` field of `MsgSaveProfile` to `profile_picture`
-- Moved profile module constants to chain parameters (#171)
+- Moved profile module constants to chain parameters (#171) 
 
 ## Bug fixes
 - Fixed a bug inside the `Equals` method of the `Pictures` object 
+- Changed the `tx profiles save` flags names (fixes #207)
 
 # Version 0.7.0
 ## Changes

--- a/cli_test/cli_profile_test.go
+++ b/cli_test/cli_profile_test.go
@@ -28,7 +28,7 @@ func TestDesmosCLIProfileCreate_noFlags(t *testing.T) {
 	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
 
 	// Create a profile
-	success, _, sterr := f.TxProfileSave(fooAddr, "-y", "--dtag mrBrown")
+	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y")
 	require.True(t, success)
 	require.Empty(t, sterr)
 	tests.WaitForNextNBlocksTM(1, f.Port)
@@ -40,12 +40,11 @@ func TestDesmosCLIProfileCreate_noFlags(t *testing.T) {
 	require.Equal(t, profile.DTag, "mrBrown")
 
 	// Test --dry-run
-	success, _, _ = f.TxProfileSave(fooAddr, "--dry-run", "--dtag mrBrown")
+	success, _, _ = f.TxProfileSave("mrBrown", fooAddr, "--dry-run")
 	require.True(t, success)
 
 	// Test --generate-only
-	success, stdout, stderr := f.TxProfileSave(fooAddr, "--generate-only=true",
-		"--moniker mrBrown")
+	success, stdout, stderr := f.TxProfileSave("mrBrown", fooAddr, "--generate-only=true")
 	require.Empty(t, stderr)
 	require.True(t, success)
 	msg := unmarshalStdTx(f.T, stdout)
@@ -77,8 +76,7 @@ func TestDesmosCLIProfileCreate_withFlags(t *testing.T) {
 	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
 
 	// Create a profile
-	success, _, sterr := f.TxProfileSave(fooAddr, "-y",
-		"--dtag mrBrown",
+	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leonardo",
 		"--bio biography",
 		"--picture https://profilePic.jpg",
@@ -93,8 +91,7 @@ func TestDesmosCLIProfileCreate_withFlags(t *testing.T) {
 	require.Equal(t, *storedProfiles[0].Moniker, "Leonardo")
 
 	// Test --dry-run
-	success, _, _ = f.TxProfileSave(fooAddr, "--dry-run",
-		"--dtag mrBrown",
+	success, _, _ = f.TxProfileSave("mrBrown", fooAddr, "--dry-run",
 		"--moniker Leonardo",
 		"--bio biography",
 		"--picture https://profilePic.jpg",
@@ -102,8 +99,7 @@ func TestDesmosCLIProfileCreate_withFlags(t *testing.T) {
 	require.True(t, success)
 
 	// Test --generate-only
-	success, stdout, stderr := f.TxProfileSave(fooAddr, "--generate-only=true",
-		"--dtag mrBrown",
+	success, stdout, stderr := f.TxProfileSave("mrBrown", fooAddr, "--generate-only=true",
 		"--moniker Leonardo",
 		"--bio biography",
 		"--picture https://profilePic.jpg",
@@ -139,8 +135,7 @@ func TestDesmosCLIProfileEdit_noFlags(t *testing.T) {
 	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
 
 	// Create a profile
-	success, _, sterr := f.TxProfileSave(fooAddr, "-y",
-		"--dtag mrBrown",
+	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leonardo",
 		"--bio biography",
 		"--picture https://profilePic.jpg",
@@ -157,7 +152,7 @@ func TestDesmosCLIProfileEdit_noFlags(t *testing.T) {
 	require.Equal(t, *profile.Moniker, "Leonardo")
 
 	// Edit the profile
-	success, _, sterr = f.TxProfileSave(fooAddr, "-y", "--dtag mrBrown")
+	success, _, sterr = f.TxProfileSave("mrBrown", fooAddr, "-y")
 	require.True(t, success)
 	require.Empty(t, sterr)
 	tests.WaitForNextNBlocksTM(1, f.Port)
@@ -171,11 +166,11 @@ func TestDesmosCLIProfileEdit_noFlags(t *testing.T) {
 	require.Nil(t, editedProfiles[0].Bio)
 
 	// Test --dry-run
-	success, _, _ = f.TxProfileSave(fooAddr, "--dry-run", "--dtag mrPink")
+	success, _, _ = f.TxProfileSave("mrPink", fooAddr, "--dry-run")
 	require.True(t, success)
 
 	// Test --generate-only
-	success, stdout, stderr := f.TxProfileSave(fooAddr, "--moniker mrPink", "--generate-only=true")
+	success, stdout, stderr := f.TxProfileSave("mrPink", fooAddr, "--generate-only=true")
 	require.Empty(t, stderr)
 	require.True(t, success)
 	msg := unmarshalStdTx(f.T, stdout)
@@ -207,8 +202,7 @@ func TestDesmosCLIProfileEdit_withFlags(t *testing.T) {
 	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
 
 	// Create a profile
-	success, _, sterr := f.TxProfileSave(fooAddr, "-y",
-		"--dtag mrBrown",
+	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leonardo",
 		"--bio biography",
 		"--picture https://profilePic.jpg",
@@ -224,8 +218,7 @@ func TestDesmosCLIProfileEdit_withFlags(t *testing.T) {
 	require.Equal(t, *profile.Moniker, "Leonardo")
 
 	// Edit the profile
-	success, _, sterr = f.TxProfileSave(fooAddr, "-y",
-		"--dtag mrBrown",
+	success, _, sterr = f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leo",
 		"--bio HollywoodActor",
 		"--picture https://profilePic.jpg",
@@ -246,8 +239,7 @@ func TestDesmosCLIProfileEdit_withFlags(t *testing.T) {
 	require.NotEqual(t, storedProfiles[0].Bio, editedProfiles[0].Bio)
 
 	// Test --dry-run
-	success, _, _ = f.TxProfileSave(fooAddr, "--dry-run",
-		"--dtag mrPink",
+	success, _, _ = f.TxProfileSave("mrPink", fooAddr, "--dry-run",
 		"--moniker Leo",
 		"--bio HollywoodActor",
 		"--picture https://profilePic.jpg",
@@ -255,8 +247,7 @@ func TestDesmosCLIProfileEdit_withFlags(t *testing.T) {
 	require.True(t, success)
 
 	// Test --generate-only
-	success, stdout, stderr := f.TxProfileSave(fooAddr, "--generate-only=true",
-		"--dtag mrPink",
+	success, stdout, stderr := f.TxProfileSave("mrPink", fooAddr, "--generate-only=true",
 		"--moniker Leo",
 		"--bio HollywoodActor",
 		"--picture https://profilePic.jpg",
@@ -292,7 +283,7 @@ func TestDesmosCLIProfileDelete(t *testing.T) {
 	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
 
 	// Create a profile
-	success, _, sterr := f.TxProfileSave(fooAddr, "-y", "--dtag mrBrown")
+	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y")
 	require.True(t, success)
 	require.Empty(t, sterr)
 	tests.WaitForNextNBlocksTM(1, f.Port)

--- a/cli_test/cli_profile_test.go
+++ b/cli_test/cli_profile_test.go
@@ -79,8 +79,8 @@ func TestDesmosCLIProfileCreate_withFlags(t *testing.T) {
 	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leonardo",
 		"--bio biography",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg")
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg")
 	require.True(t, success)
 	require.Empty(t, sterr)
 	tests.WaitForNextNBlocksTM(1, f.Port)
@@ -94,16 +94,16 @@ func TestDesmosCLIProfileCreate_withFlags(t *testing.T) {
 	success, _, _ = f.TxProfileSave("mrBrown", fooAddr, "--dry-run",
 		"--moniker Leonardo",
 		"--bio biography",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg")
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg")
 	require.True(t, success)
 
 	// Test --generate-only
 	success, stdout, stderr := f.TxProfileSave("mrBrown", fooAddr, "--generate-only=true",
 		"--moniker Leonardo",
 		"--bio biography",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg")
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg")
 	require.Empty(t, stderr)
 	require.True(t, success)
 	msg := unmarshalStdTx(f.T, stdout)
@@ -138,8 +138,8 @@ func TestDesmosCLIProfileEdit_noFlags(t *testing.T) {
 	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leonardo",
 		"--bio biography",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg",
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg",
 	)
 	require.True(t, success)
 	require.Empty(t, sterr)
@@ -205,8 +205,8 @@ func TestDesmosCLIProfileEdit_withFlags(t *testing.T) {
 	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leonardo",
 		"--bio biography",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg")
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg")
 	require.True(t, success)
 	require.Empty(t, sterr)
 	tests.WaitForNextNBlocksTM(1, f.Port)
@@ -221,8 +221,8 @@ func TestDesmosCLIProfileEdit_withFlags(t *testing.T) {
 	success, _, sterr = f.TxProfileSave("mrBrown", fooAddr, "-y",
 		"--moniker Leo",
 		"--bio HollywoodActor",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg")
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg")
 	require.True(t, success)
 	require.Empty(t, sterr)
 	tests.WaitForNextNBlocksTM(1, f.Port)
@@ -242,16 +242,16 @@ func TestDesmosCLIProfileEdit_withFlags(t *testing.T) {
 	success, _, _ = f.TxProfileSave("mrPink", fooAddr, "--dry-run",
 		"--moniker Leo",
 		"--bio HollywoodActor",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg")
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg")
 	require.True(t, success)
 
 	// Test --generate-only
 	success, stdout, stderr := f.TxProfileSave("mrPink", fooAddr, "--generate-only=true",
 		"--moniker Leo",
 		"--bio HollywoodActor",
-		"--picture https://profilePic.jpg",
-		"--cover https://profileCover.jpg")
+		"--profile-pic https://profilePic.jpg",
+		"--cover-pic https://profileCover.jpg")
 	require.Empty(t, stderr)
 	require.True(t, success)
 	msg := unmarshalStdTx(f.T, stdout)

--- a/cli_test/test_helpers.go
+++ b/cli_test/test_helpers.go
@@ -458,9 +458,9 @@ func (f *Fixtures) TxPostsRegisterReaction(shortCode, value, subspace string, fr
 
 //___________________________________________________________________________________
 // desmoscli tx profile
-func (f *Fixtures) TxProfileSave(from sdk.AccAddress, flags ...string) (bool, string, string) {
-	cmd := fmt.Sprintf(`%s tx profiles save --keyring-backend=test --from=%s %v`,
-		f.DesmoscliBinary, from, f.Flags())
+func (f *Fixtures) TxProfileSave(dTag string, from sdk.AccAddress, flags ...string) (bool, string, string) {
+	cmd := fmt.Sprintf(`%s tx profiles save %s --keyring-backend=test --from=%s %v`,
+		f.DesmoscliBinary, dTag, from, f.Flags())
 	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags), clientkeys.DefaultKeyPass)
 }
 

--- a/x/profiles/client/cli/keys.go
+++ b/x/profiles/client/cli/keys.go
@@ -1,9 +1,8 @@
 package cli
 
 const (
-	flagDtag         = "dtag"
-	flagMoniker      = "moniker"
-	flagBio          = "bio"
-	flagProfilePic   = "picture"
-	flagProfileCover = "cover"
+	flagMoniker    = "moniker"
+	flagBio        = "bio"
+	flagProfilePic = "profile-pic"
+	flagCoverPic   = "cover-pic"
 )

--- a/x/profiles/client/cli/tx.go
+++ b/x/profiles/client/cli/tx.go
@@ -46,44 +46,41 @@ func getFlagValueOrNilOnDefault(flag string) *string {
 // GetCmdSaveProfile is the CLI command for saving an profile
 func GetCmdSaveProfile(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "save",
-		Short: "Save a profile",
+		Use:   "save [dtag]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Save your profile associating to it the given DTag.",
 		Long: fmt.Sprintf(`
-Save a new profile or edit an existing one specifying the dtag, name, surname, bio, a profile picture and cover.
-Every data is optional except for the dtag.
-If you are editing an existing profile you should fill all the existent fields otherwise they will be set as nil.
+Save a new profile or edit the existing one specifying a DTag, a moniker, biography, profile picture and cover picture.
+Every data given through the flags is optional.
+If you are editing an existing profile you should fill all the existent fields otherwise the existing values
+will be removed.
 
-%s tx profiles save \
-    --dtag "DiCapLeo" \
-	--name "Leonardo" \
-	--surname "Di Caprio" \
-	--bio "Hollywood actor. Proud environmentalist" \
-	--picture "https://profilePic.jpg"
-	--cover "https://profileCover.jpg"
-`, version.ClientName),
-		Args: cobra.ExactArgs(0),
+%s tx profiles save LeoDiCap \
+	%s "Leonardo Di Caprio" \
+	%s "Hollywood actor. Proud environmentalist" \
+	%s "https://profilePic.jpg"
+	%s "https://profileCover.jpg"
+`, version.ClientName, flagMoniker, flagBio, flagProfilePic, flagCoverPic),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContextWithInput(inBuf).WithCodec(cdc)
 
-			dtag := viper.GetString(flagDtag)
 			moniker := getFlagValueOrNilOnDefault(flagMoniker)
 			picture := getFlagValueOrNilOnDefault(flagProfilePic)
-			cover := getFlagValueOrNilOnDefault(flagProfileCover)
+			cover := getFlagValueOrNilOnDefault(flagCoverPic)
 			bio := getFlagValueOrNilOnDefault(flagBio)
 
-			msg := types.NewMsgSaveProfile(dtag, moniker, bio, picture, cover, cliCtx.FromAddress)
+			msg := types.NewMsgSaveProfile(args[0], moniker, bio, picture, cover, cliCtx.FromAddress)
 
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
 
-	cmd.Flags().String(flagDtag, "", "DTag of the user")
-	cmd.Flags().String(flagMoniker, "", "Moniker of the user")
-	cmd.Flags().String(flagBio, "", "Biography of the user")
-	cmd.Flags().String(flagProfilePic, "", "User profile picture")
-	cmd.Flags().String(flagProfileCover, "", "User cover picture")
+	cmd.Flags().String(flagMoniker, "", "Moniker to be used")
+	cmd.Flags().String(flagBio, "", "Biography to be used")
+	cmd.Flags().String(flagProfilePic, "", "Profile picture")
+	cmd.Flags().String(flagCoverPic, "", "Cover picture")
 
 	return cmd
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Changes:
- Fixed the `tx profiles save --help` description (fixes #206) 
- Changed the `tx profiles save` flags names (fixes #207)
- Fixed the `tx profiles save` form moving the DTag to the arguments (fixes #208) 


## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit tests.
- [x] Wrote integration tests (simulation & CLI). 
- [ ] Updated the documentation. 
- [x] Added an entry to the `CHANGELOG.md` file.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
