### PR TITLE
Remove relationship event key prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.13.0
+## Changes
+- Removed the relationship event attribute key prefix. (#291)
+
 # Version 0.12.3
 ## Changes
 - Renamed the `accept-dtag-transfer` CLI command to remove the `.md` suffix (#282)

--- a/x/relationships/types/events.go
+++ b/x/relationships/types/events.go
@@ -6,9 +6,9 @@ const (
 	EventTypeRelationshipsDeleted = "relationships_deleted"
 
 	// Relationships attributes
-	AttributeRelationshipSender   = "relationship_sender"
-	AttributeRelationshipReceiver = "relationship_receiver"
-	AttributeRelationshipSubspace = "relationship_subspace"
+	AttributeRelationshipSender   = "sender"
+	AttributeRelationshipReceiver = "receiver"
+	AttributeRelationshipSubspace = "subspace"
 
 	// UserBlocks events
 	EventTypeBlockUser   = "block_user"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR removes the `relationship` event key prefix.
Closes #300. 
## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [ ] Wrote integration tests (simulation & CLI). 
- [ ] Updated the documentation. 
- [x] Added an entry to the `CHANGELOG.md` file.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
