### PR TITLE
Empty dTag transfer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.13.0
+## Changes
+- Removed the relationship event attribute key prefix. (#291)
+
 # Version 0.12.3
 ## Changes
 - Renamed the `accept-dtag-transfer` CLI command to remove the `.md` suffix (#282)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Changes
 - Removed the relationship event attribute key prefix (#300)
 - Removed the user_block event attribute key prefix (#291)
-- Fixed the possibility to request a transfer for an empty dTag (#292)
+- Fixed the possibility of requesting a transfer of an empty DTag (#292)
 
 # Version 0.12.3
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Version 0.13.0
 ## Changes
-- Removed the relationship event attribute key prefix. (#300)
-- Removed the user_block event attribute key prefix. (#291)
+- Removed the relationship event attribute key prefix (#300)
+- Removed the user_block event attribute key prefix (#291)
+- Fixed the possibility to request a transfer for an empty dTag (#292)
 
 # Version 0.12.3
 ## Changes

--- a/cli_test/cli_profile_test.go
+++ b/cli_test/cli_profile_test.go
@@ -344,7 +344,7 @@ func TestDesmosCLIRequestDTagTransfer(t *testing.T) {
 	f.TxSend(fooAddr.String(), barAddr, sdk.NewCoin(denom, sdk.NewInt(1000)), "-y")
 	f.TxSend(fooAddr.String(), calAddr, sdk.NewCoin(denom, sdk.NewInt(1000)), "-y")
 
-	// Create the profile of the dTag owner
+	// Create the profile of the DTag owner
 	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y")
 	require.True(t, success)
 	require.Empty(t, sterr)

--- a/cli_test/cli_profile_test.go
+++ b/cli_test/cli_profile_test.go
@@ -339,34 +339,46 @@ func TestDesmosCLIRequestDTagTransfer(t *testing.T) {
 
 	// Save key addresses for later use
 	fooAddr := f.KeyAddress(keyFoo)
+	barAddr := f.KeyAddress(keyBar)
+	calAddr := f.KeyAddress(keyBaz)
+	f.TxSend(fooAddr.String(), barAddr, sdk.NewCoin(denom, sdk.NewInt(1000)), "-y")
+	f.TxSend(fooAddr.String(), calAddr, sdk.NewCoin(denom, sdk.NewInt(1000)), "-y")
 
-	// Later usage variables
-	fooAcc := f.QueryAccount(fooAddr)
-	startTokens := sdk.TokensFromConsensusPower(140)
-	require.Equal(t, startTokens, fooAcc.GetCoins().AmountOf(denom))
+	// Create the profile of the dTag owner
+	success, _, sterr := f.TxProfileSave("mrBrown", fooAddr, "-y")
+	require.True(t, success)
+	require.Empty(t, sterr)
+	tests.WaitForNextNBlocksTM(1, f.Port)
 
-	owner, err := sdk.AccAddressFromBech32("desmos15ux5mc98jlhsg30dzwwv06ftjs82uy4g3t99ru")
-	require.NoError(t, err)
-
-	owner2, err := sdk.AccAddressFromBech32("desmos16namwr0llz5p82kug58fx7xp3rccqfp25j30h6")
-	require.NoError(t, err)
+	// Make sure the profile is saved
+	storedProfiles := f.QueryProfiles()
+	require.NotEmpty(t, storedProfiles)
+	profile := storedProfiles[0]
+	require.Equal(t, profile.DTag, "mrBrown")
 
 	// Create a request
-	success, _, sterr := f.TxProfileRequestDTagTransfer(owner, fooAddr, "-y")
+	success, _, sterr = f.TxProfileRequestDTagTransfer(fooAddr, barAddr, "-y")
 	require.True(t, success)
 	require.Empty(t, sterr)
 	tests.WaitForNextNBlocksTM(1, f.Port)
 
 	// Make sure the request is saved
-	storedRequests := f.QueryUserDTagRequests(owner)
+	storedRequests := f.QueryUserDTagRequests(fooAddr)
 	require.NotEmpty(t, storedRequests)
 
 	// Test --dry-run
-	success, _, _ = f.TxProfileRequestDTagTransfer(owner2, fooAddr, "--dry-run")
+
+	// Create the profile of the dTag owner
+	success, _, sterr = f.TxProfileSave("mrPink", calAddr, "-y")
+	require.True(t, success)
+	require.Empty(t, sterr)
+	tests.WaitForNextNBlocksTM(1, f.Port)
+
+	success, _, _ = f.TxProfileRequestDTagTransfer(calAddr, fooAddr, "--dry-run")
 	require.True(t, success)
 
 	// Test --generate-only
-	success, stdout, stderr := f.TxProfileRequestDTagTransfer(owner2, fooAddr, "--generate-only=true")
+	success, stdout, stderr := f.TxProfileRequestDTagTransfer(calAddr, fooAddr, "--generate-only=true")
 	require.Empty(t, stderr)
 	require.True(t, success)
 	msg := unmarshalStdTx(f.T, stdout)

--- a/x/profiles/keeper/handler.go
+++ b/x/profiles/keeper/handler.go
@@ -153,6 +153,11 @@ func handleMsgDeleteProfile(ctx sdk.Context, keeper Keeper, msg types.MsgDeleteP
 // handleMsgRequestDTagTransfer handles the request of a dTag transfer
 func handleMsgRequestDTagTransfer(ctx sdk.Context, keeper Keeper, msg types.MsgRequestDTagTransfer) (*sdk.Result, error) {
 	dtagToTrade := keeper.GetDtagFromAddress(ctx, msg.CurrentOwner)
+	if len(dtagToTrade) == 0 {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
+			fmt.Sprintf("The user with address %s doesn't have a profile yet so no dTag can be transferred",
+				msg.CurrentOwner))
+	}
 	transferRequest := types.NewDTagTransferRequest(dtagToTrade, msg.CurrentOwner, msg.ReceivingUser)
 
 	if err := keeper.SaveDTagTransferRequest(ctx, transferRequest); err != nil {

--- a/x/profiles/keeper/handler.go
+++ b/x/profiles/keeper/handler.go
@@ -155,7 +155,7 @@ func handleMsgRequestDTagTransfer(ctx sdk.Context, keeper Keeper, msg types.MsgR
 	dtagToTrade := keeper.GetDtagFromAddress(ctx, msg.CurrentOwner)
 	if len(dtagToTrade) == 0 {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
-			fmt.Sprintf("The user with address %s doesn't have a profile yet so no dTag can be transferred",
+			fmt.Sprintf("The user with address %s doesn't have a profile yet so their dTag cannot be transferred",
 				msg.CurrentOwner))
 	}
 	transferRequest := types.NewDTagTransferRequest(dtagToTrade, msg.CurrentOwner, msg.ReceivingUser)

--- a/x/profiles/keeper/handler_test.go
+++ b/x/profiles/keeper/handler_test.go
@@ -327,7 +327,7 @@ func (suite *KeeperTestSuite) Test_handleMsgRequestDTagTransfer() {
 			storedDTagReqs: nil,
 			hasProfile:     false,
 			expErr: sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
-				fmt.Sprintf("The user with address %s doesn't have a profile yet so no dTag can be transfered",
+				fmt.Sprintf("The user with address %s doesn't have a profile yet so no dTag can be transferred",
 					suite.testData.otherUser)),
 		},
 		{

--- a/x/profiles/keeper/handler_test.go
+++ b/x/profiles/keeper/handler_test.go
@@ -316,16 +316,27 @@ func (suite *KeeperTestSuite) Test_handleMsgRequestDTagTransfer() {
 	tests := []struct {
 		name           string
 		msg            types.MsgRequestDTagTransfer
+		hasProfile     bool
 		storedDTagReqs []types.DTagTransferRequest
 		expErr         error
 		expEvent       sdk.Event
 	}{
+		{
+			name:           "No DTag to transfer returns error",
+			msg:            types.NewMsgRequestDTagTransfer(suite.testData.otherUser, suite.testData.user),
+			storedDTagReqs: nil,
+			hasProfile:     false,
+			expErr: sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
+				fmt.Sprintf("The user with address %s doesn't have a profile yet so no dTag can be transfered",
+					suite.testData.otherUser)),
+		},
 		{
 			name: "Already present request returns error",
 			msg:  types.NewMsgRequestDTagTransfer(suite.testData.user, suite.testData.otherUser),
 			storedDTagReqs: []types.DTagTransferRequest{
 				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
 			},
+			hasProfile: true,
 			expErr: sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
 				fmt.Sprintf("the transfer request from %s to %s has already been made",
 					suite.testData.otherUser, suite.testData.user)),
@@ -334,6 +345,7 @@ func (suite *KeeperTestSuite) Test_handleMsgRequestDTagTransfer() {
 			name:           "Not already present request saved correctly",
 			msg:            types.NewMsgRequestDTagTransfer(suite.testData.user, suite.testData.otherUser),
 			storedDTagReqs: nil,
+			hasProfile:     true,
 			expErr:         nil,
 			expEvent: sdk.NewEvent(
 				types.EventTypeDTagTransferRequest,
@@ -354,7 +366,9 @@ func (suite *KeeperTestSuite) Test_handleMsgRequestDTagTransfer() {
 				)
 			}
 
-			suite.keeper.AssociateDtagWithAddress(suite.ctx, "dtag", suite.testData.user)
+			if test.hasProfile {
+				suite.keeper.AssociateDtagWithAddress(suite.ctx, "dtag", suite.testData.user)
+			}
 
 			handler := keeper.NewHandler(suite.keeper)
 			res, err := handler(suite.ctx, test.msg)

--- a/x/profiles/keeper/handler_test.go
+++ b/x/profiles/keeper/handler_test.go
@@ -327,7 +327,7 @@ func (suite *KeeperTestSuite) Test_handleMsgRequestDTagTransfer() {
 			storedDTagReqs: nil,
 			hasProfile:     false,
 			expErr: sdkerrors.Wrap(sdkerrors.ErrInvalidRequest,
-				fmt.Sprintf("The user with address %s doesn't have a profile yet so no dTag can be transferred",
+				fmt.Sprintf("The user with address %s doesn't have a profile yet so their dTag cannot be transferred",
 					suite.testData.otherUser)),
 		},
 		{

--- a/x/relationships/types/events.go
+++ b/x/relationships/types/events.go
@@ -6,9 +6,9 @@ const (
 	EventTypeRelationshipsDeleted = "relationships_deleted"
 
 	// Relationships attributes
-	AttributeRelationshipSender   = "relationship_sender"
-	AttributeRelationshipReceiver = "relationship_receiver"
-	AttributeRelationshipSubspace = "relationship_subspace"
+	AttributeRelationshipSender   = "sender"
+	AttributeRelationshipReceiver = "receiver"
+	AttributeRelationshipSubspace = "subspace"
 
 	// UserBlocks events
 	EventTypeBlockUser   = "block_user"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes the possibility to request a transfer of an empty dTag.
This situation occurs when the dTag owner doesn't have a profile.
Closes #293 .
## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit tests.
- [x] Wrote integration tests (simulation & CLI). 
- [ ] Updated the documentation. 
- [x] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
