### PR TITLE
Simulation tests fixes

### DIFF
--- a/x/profiles/simulation/genesis.go
+++ b/x/profiles/simulation/genesis.go
@@ -58,19 +58,33 @@ func randomRelationships(simState *module.SimulationState) []types.Relationship 
 	relationshipsNumber := simState.Rand.Intn(simtypes.RandIntBetween(simState.Rand, 1, 30))
 
 	relationships := make([]types.Relationship, relationshipsNumber)
-	for index := 0; index < relationshipsNumber; index++ {
+	for index := 0; index < relationshipsNumber; {
 		sender, _ := simtypes.RandomAcc(simState.Rand, simState.Accounts)
 		receiver, _ := simtypes.RandomAcc(simState.Rand, simState.Accounts)
 		if !sender.Equals(receiver) {
-			relationships[index] = types.NewRelationship(
+			newRelationship := types.NewRelationship(
 				sender.Address.String(),
 				receiver.Address.String(),
 				RandomSubspace(simState.Rand),
 			)
+			if !containsRelationship(relationships, newRelationship) {
+				relationships[index] = newRelationship
+				index++
+			}
 		}
 	}
 
 	return relationships
+}
+
+// containsRelationship returns true iff the given slice contains the given relationship
+func containsRelationship(slice []types.Relationship, relationship types.Relationship) bool {
+	for _, rel := range slice {
+		if rel.Equal(relationship) {
+			return true
+		}
+	}
+	return false
 }
 
 // randomUsersBlocks


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes the bugs that were present inside the simulation tests for the `x/profiles` module.  
Now, when creating genesis relationships, we check for double ones and avoid inserting them. This allows to avoid having the chain explode at genesis.

## Checklist
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit tests.
- [ ] Wrote integration tests (simulation & CLI). 
- [ ] Updated the documentation. 
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
