### PR TITLE
Add sign command

### DIFF
--- a/app/desmos/cmd/root.go
+++ b/app/desmos/cmd/root.go
@@ -7,8 +7,6 @@ import (
 
 	config "github.com/cosmos/cosmos-sdk/client/config"
 
-	themiscli "github.com/desmos-labs/desmos/x/themis/client/cli"
-
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 
 	"github.com/desmos-labs/desmos/app"
@@ -111,7 +109,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		rpc.StatusCommand(),
 		queryCommand(),
 		txCommand(),
-		themiscli.GetRootCmd(),
+		GetSignCmd(),
 		keys.Commands(app.DefaultNodeHome),
 	)
 }

--- a/app/desmos/cmd/sign.go
+++ b/app/desmos/cmd/sign.go
@@ -1,9 +1,10 @@
-package cli
+package cmd
 
 import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -11,18 +12,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// GetRootCmd returns the root command for the themis module
-func GetRootCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "themis",
-		Short: "Subcommands for the Themis module",
-	}
-
-	cmd.AddCommand(
-		GetSignCmd(),
-	)
-
-	return cmd
+type SignatureData struct {
+	Address   string `json:"address"`
+	PubKey    string `json:"pub_key"`
+	Signature string `json:"signature"`
+	Value     string `json:"value"`
 }
 
 // GetSignCmd returns the command allowing to sign an arbitrary for later verification
@@ -59,15 +53,10 @@ func GetSignCmd() *cobra.Command {
 			}
 
 			// Build the signature data output
-			signatureData := struct {
-				Address   string `json:"address"`
-				PubKey    string `json:"pub_key"`
-				Signature string `json:"signature"`
-				Value     string `json:"value"`
-			}{
-				Address:   pubKey.Address().String(),
-				Signature: hex.EncodeToString(bz),
-				PubKey:    hex.EncodeToString(pubKey.Bytes()),
+			signatureData := SignatureData{
+				Address:   strings.ToLower(pubKey.Address().String()),
+				Signature: strings.ToLower(hex.EncodeToString(bz)),
+				PubKey:    strings.ToLower(hex.EncodeToString(pubKey.Bytes())),
 				Value:     value,
 			}
 
@@ -76,9 +65,8 @@ func GetSignCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cmd.Print(string(bz))
 
-			return nil
+			return clientCtx.PrintBytes(bz)
 		},
 	}
 

--- a/app/desmos/cmd/sign_test.go
+++ b/app/desmos/cmd/sign_test.go
@@ -1,0 +1,58 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/desmos-labs/desmos/app"
+	cmd "github.com/desmos-labs/desmos/app/desmos/cmd"
+)
+
+func TestGetSignCmd(t *testing.T) {
+	cfg := sdk.GetConfig()
+	app.SetupConfig(cfg)
+	cfg.Seal()
+
+	keyBase := keyring.NewInMemory()
+	algo := hd.Secp256k1
+	hdPath := sdk.GetConfig().GetFullFundraiserPath()
+
+	keyName := "test"
+	mnemonic := "clip toilet stairs jaguar baby over mosquito capital speed mule adjust eye print voyage verify smart open crack imitate auto gauge museum planet rebel"
+	_, err := keyBase.NewAccount(keyName, mnemonic, "", hdPath, algo)
+	require.NoError(t, err)
+
+	output := os.Stdout
+	clientCtx := client.Context{}.
+		WithKeyring(keyBase).
+		WithOutput(output)
+
+	out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd.GetSignCmd(), []string{
+		"This is my signed value",
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, keyName),
+	})
+	require.NoError(t, err)
+
+	var data cmd.SignatureData
+	err = json.Unmarshal(out.Bytes(), &data)
+	require.NoError(t, err)
+
+	expected := cmd.SignatureData{
+		Address:   "d133e902b523aa568f0086609c958c83ac0c4fc1",
+		PubKey:    "03f3fa3e31c3c2833c92b83f26ef29397991acfeb0fbaad8864d047cdd6a0cc155",
+		Signature: "5d492db8df4a6f912188610395574d36cdbaadec00e64bc6341722e81fe38cae7d8b7e6d2896f1fba03e45dd2a9534cab205347f00e177de6796a46811cfa35f",
+		Value:     "This is my signed value",
+	}
+	require.Equal(t, expected, data)
+
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR adds the `sign` command to the `desmos` root command, allowing to sign any data. No changelog entry is required since this is part of the things that are needed in order to implement applications links

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [ ] Wrote integration tests (simulation & CLI). 
- [ ] Updated the documentation. 
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
