### PR TITLE
Profiles keeper tests improvements

### DIFF
--- a/testutil/profiles.go
+++ b/testutil/profiles.go
@@ -1,6 +1,9 @@
 package testutil
 
 import (
+	"fmt"
+	"time"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -39,4 +42,20 @@ func PubKeyFromBech32(pubKey string) cryptotypes.PubKey {
 		panic(err)
 	}
 	return publicKey
+}
+
+func ProfileFromAddr(address string) *types.Profile {
+	profile, err := types.NewProfile(
+		fmt.Sprintf("%s-dtag", address),
+		"",
+		"",
+		types.NewPictures("", ""),
+		time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
+		AccountFromAddr(address),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return profile
 }

--- a/x/profiles/keeper/alias_functions_test.go
+++ b/x/profiles/keeper/alias_functions_test.go
@@ -3,6 +3,8 @@ package keeper_test
 import (
 	"time"
 
+	"github.com/desmos-labs/desmos/testutil"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -120,7 +122,7 @@ func (suite *KeeperTestSuite) TestKeeper_IterateUserIncomingDTagTransferRequests
 	}
 
 	for _, request := range requests {
-		profile := suite.CreateProfileFromAddress(address)
+		profile := testutil.ProfileFromAddr(address)
 		err := suite.k.StoreProfile(suite.ctx, profile)
 		suite.Require().NoError(err)
 
@@ -183,7 +185,7 @@ func (suite *KeeperTestSuite) TestKeeper_IterateUserApplicationLinks() {
 	ctx, _ := suite.ctx.CacheContext()
 
 	for _, link := range links {
-		suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(link.User))
+		suite.ak.SetAccount(ctx, testutil.ProfileFromAddr(link.User))
 
 		err := suite.k.SaveApplicationLink(ctx, link)
 		suite.Require().NoError(err)
@@ -245,7 +247,7 @@ func (suite *KeeperTestSuite) TestKeeper_GetApplicationLinksEntries() {
 	ctx, _ := suite.ctx.CacheContext()
 
 	for _, link := range links {
-		suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(link.User))
+		suite.ak.SetAccount(ctx, testutil.ProfileFromAddr(link.User))
 
 		err := suite.k.SaveApplicationLink(ctx, link)
 		suite.Require().NoError(err)

--- a/x/profiles/keeper/common_test.go
+++ b/x/profiles/keeper/common_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -44,22 +43,18 @@ func TestKeeperTestSuite(t *testing.T) {
 type KeeperTestSuite struct {
 	suite.Suite
 
-	cdc            codec.Marshaler
-	legacyAminoCdc *codec.LegacyAmino
-	ctx            sdk.Context
-	storeKey       sdk.StoreKey
-	k              keeper.Keeper
-	ak             authkeeper.AccountKeeper
-	paramsKeeper   paramskeeper.Keeper
-
-	// for IBC
+	cdc              codec.Marshaler
+	legacyAminoCdc   *codec.LegacyAmino
+	ctx              sdk.Context
+	storeKey         sdk.StoreKey
+	k                keeper.Keeper
+	ak               authkeeper.AccountKeeper
+	paramsKeeper     paramskeeper.Keeper
 	stakingKeeper    stakingkeeper.Keeper
 	IBCKeeper        *ibckeeper.Keeper
 	capabilityKeeper *capabilitykeeper.Keeper
 
-	testData TestData
-
-	// for ibc test
+	// Used for IBC testing
 	coordinator *ibctesting.Coordinator
 	chainA      *ibctesting.TestChain
 	chainB      *ibctesting.TestChain
@@ -152,44 +147,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 
 	// Set the IBC data
 	suite.initIBCConnection()
-
-	// Set test data
-	suite.testData.user = "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"
-	suite.testData.otherUser = "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"
-	suite.initProfile()
-}
-
-func (suite *KeeperTestSuite) initProfile() {
-	mnemonic := "ugly like hockey joy digital glow learn remove pet promote screen twenty phone beach aspect mechanic gate piano antenna island loyal possible acoustic jewel"
-	derivedPrivKey, err := hd.Secp256k1.Derive()(mnemonic, "", sdk.FullFundraiserPath)
-	suite.Require().NoError(err)
-
-	privKey := hd.Secp256k1.Generate()(derivedPrivKey)
-
-	// Create the base account and set inside the auth keeper.
-	// This is done in order to make sure that when we try to create a profile using the above address, the profile
-	// can be created properly. Not storing the base account would end up in the following error since it's null:
-	// "the given account cannot be serialized using Protobuf"
-	baseAcc := authtypes.NewBaseAccount(sdk.AccAddress(privKey.PubKey().Address()), privKey.PubKey(), 0, 0)
-	suite.ak.SetAccount(suite.ctx, baseAcc)
-
-	profile, err := types.NewProfile(
-		"dtag",
-		"test-user",
-		"biography",
-		types.NewPictures(
-			"https://shorturl.at/adnX3",
-			"https://shorturl.at/cgpyF",
-		),
-		time.Date(2019, 1, 1, 00, 00, 00, 000, time.UTC),
-		baseAcc,
-	)
-	suite.Require().NoError(err)
-
-	suite.testData.profile = TestProfile{
-		Profile: profile,
-		privKey: privKey,
-	}
 }
 
 func (suite *KeeperTestSuite) initIBCConnection() {
@@ -232,23 +189,6 @@ func (suite *KeeperTestSuite) GetRandomProfile() TestProfile {
 		Profile: profile,
 		privKey: privKey,
 	}
-}
-
-func (suite *KeeperTestSuite) CreateProfileFromAddress(address string) *types.Profile {
-	addr, err := sdk.AccAddressFromBech32(address)
-	suite.Require().NoError(err)
-
-	profile, err := types.NewProfile(
-		fmt.Sprintf("%s-dtag", address),
-		"",
-		"",
-		types.NewPictures("", ""),
-		time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
-		authtypes.NewBaseAccountWithAddress(addr),
-	)
-	suite.Require().NoError(err)
-
-	return profile
 }
 
 func (suite *KeeperTestSuite) CheckProfileNoError(profile *types.Profile, err error) *types.Profile {

--- a/x/profiles/keeper/common_test.go
+++ b/x/profiles/keeper/common_test.go
@@ -146,10 +146,10 @@ func (suite *KeeperTestSuite) SetupTest() {
 	)
 
 	// Set the IBC data
-	suite.initIBCConnection()
+	suite.SetupIBCTest()
 }
 
-func (suite *KeeperTestSuite) initIBCConnection() {
+func (suite *KeeperTestSuite) SetupIBCTest() {
 	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 2)
 	suite.chainA = suite.coordinator.GetChain(ibctesting.GetChainID(0))
 	suite.chainB = suite.coordinator.GetChain(ibctesting.GetChainID(1))
@@ -169,10 +169,10 @@ func (suite *KeeperTestSuite) GetRandomProfile() TestProfile {
 
 	privKey := hd.Secp256k1.Generate()(derivedPrivKey)
 
-	// Create the base account and set inside the auth keeper.
+	// Create the base profile and set inside the auth keeper.
 	// This is done in order to make sure that when we try to create a profile using the above address, the profile
-	// can be created properly. Not storing the base account would end up in the following error since it's null:
-	// "the given account cannot be serialized using Protobuf"
+	// can be created properly. Not storing the base profile would end up in the following error since it's null:
+	// "the given profile cannot be serialized using Protobuf"
 	baseAcc := authtypes.NewBaseAccount(sdk.AccAddress(privKey.PubKey().Address()), privKey.PubKey(), 0, 0)
 
 	profile, err := types.NewProfile(

--- a/x/profiles/keeper/grpc_query_test.go
+++ b/x/profiles/keeper/grpc_query_test.go
@@ -613,20 +613,20 @@ func (suite *KeeperTestSuite) TestQueryServer_UserBlocks() {
 	}
 
 	for _, tc := range testCases {
-		uc := tc
-		suite.Run(uc.name, func() {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
 			if tc.store != nil {
 				tc.store(ctx)
 			}
 
-			res, err := suite.k.UserBlocks(sdk.WrapSDKContext(ctx), uc.req)
-			if uc.shouldErr {
+			res, err := suite.k.UserBlocks(sdk.WrapSDKContext(ctx), tc.req)
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res)
-				suite.Require().Equal(uc.expBlocks, res.Blocks)
+				suite.Require().Equal(tc.expBlocks, res.Blocks)
 			}
 		})
 	}

--- a/x/profiles/keeper/grpc_query_test.go
+++ b/x/profiles/keeper/grpc_query_test.go
@@ -36,7 +36,7 @@ func (suite *KeeperTestSuite) TestQueryServer_Profile() {
 			expResponse: &types.QueryProfileResponse{Profile: nil},
 		},
 		{
-			name: "found profile - using DTag",
+			name: "found profile using DTag",
 			store: func(ctx sdk.Context) {
 				profile := testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
 				err := suite.k.StoreProfile(ctx, profile)
@@ -49,7 +49,7 @@ func (suite *KeeperTestSuite) TestQueryServer_Profile() {
 			},
 		},
 		{
-			name: "found profile - using address",
+			name: "found profile using address",
 			store: func(ctx sdk.Context) {
 				profile := testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
 				err := suite.k.StoreProfile(ctx, profile)
@@ -67,6 +67,9 @@ func (suite *KeeperTestSuite) TestQueryServer_Profile() {
 		tc := tc
 		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
+			}
 
 			res, err := suite.k.Profile(sdk.WrapSDKContext(ctx), tc.req)
 
@@ -77,7 +80,9 @@ func (suite *KeeperTestSuite) TestQueryServer_Profile() {
 				suite.Require().NotNil(res)
 
 				suite.Require().Equal(tc.expResponse, res)
-				suite.Require().Equal(tc.expResponse.Profile, res.Profile.GetCachedValue())
+				if tc.expResponse.Profile != nil {
+					suite.Require().Equal(tc.expResponse, res)
+				}
 			}
 		})
 	}
@@ -156,7 +161,7 @@ func (suite *KeeperTestSuite) TestQueryServer_IncomingDTagTransferRequests() {
 			expRequests: []types.DTagTransferRequest{
 				types.NewDTagTransferRequest(
 					"dtag",
-					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+					"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
 					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
 				),
 			},
@@ -226,7 +231,7 @@ func (suite *KeeperTestSuite) TestQueryServer_UserChainLinks() {
 				)
 
 				link = types.NewChainLink(
-					"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 					types.NewBech32Address("cosmos19s242dxhxgzlsdmfjjg38jgfwhxca7569g84sw", "cosmos"),
 					types.NewProof(
 						testutil.PubKeyFromBech32("cosmospub1addwnpepqvryxhhqhw52c4ny5twtfzf3fsrjqhx0x5cuya0fylw0wu0eqptykeqhr4d"),
@@ -247,7 +252,7 @@ func (suite *KeeperTestSuite) TestQueryServer_UserChainLinks() {
 			shouldErr: false,
 			expLinks: []types.ChainLink{
 				types.NewChainLink(
-					"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 					types.NewBech32Address("cosmos19s242dxhxgzlsdmfjjg38jgfwhxca7569g84sw", "cosmos"),
 					types.NewProof(
 						testutil.PubKeyFromBech32("cosmospub1addwnpepqvryxhhqhw52c4ny5twtfzf3fsrjqhx0x5cuya0fylw0wu0eqptykeqhr4d"),
@@ -460,12 +465,12 @@ func (suite *KeeperTestSuite) TestQueryServer_UserRelationships() {
 			expRelationships: []types.Relationship{
 				types.NewRelationship(
 					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+					"cosmos19mj6dkd85m84gxvf8d929w572z5h9q0u8d8wpa",
 					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 				),
 				types.NewRelationship(
 					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-					"cosmos19mj6dkd85m84gxvf8d929w572z5h9q0u8d8wpa",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 				),
 			},
@@ -558,14 +563,14 @@ func (suite *KeeperTestSuite) TestQueryServer_UserBlocks() {
 			expBlocks: []types.UserBlock{
 				types.NewUserBlock(
 					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
-					"reason1",
+					"cosmos19mj6dkd85m84gxvf8d929w572z5h9q0u8d8wpa",
+					"reason2",
 					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 				),
 				types.NewUserBlock(
 					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-					"cosmos19mj6dkd85m84gxvf8d929w572z5h9q0u8d8wpa",
-					"reason2",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+					"reason1",
 					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 				),
 			},
@@ -599,8 +604,8 @@ func (suite *KeeperTestSuite) TestQueryServer_UserBlocks() {
 			expBlocks: []types.UserBlock{
 				types.NewUserBlock(
 					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
-					"reason1",
+					"cosmos19mj6dkd85m84gxvf8d929w572z5h9q0u8d8wpa",
+					"reason2",
 					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 				),
 			},
@@ -725,7 +730,7 @@ func (suite *KeeperTestSuite) TestQueryServer_UserApplicationLinks() {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(tc.expApplicationLinks, res)
+				suite.Require().Equal(tc.expApplicationLinks, res.Links)
 			}
 		})
 	}

--- a/x/profiles/keeper/invariants_test.go
+++ b/x/profiles/keeper/invariants_test.go
@@ -4,19 +4,18 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/desmos-labs/desmos/testutil"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/desmos-labs/desmos/x/profiles/keeper"
 	"github.com/desmos-labs/desmos/x/profiles/types"
 )
 
 func (suite *KeeperTestSuite) TestInvariants() {
-	address, err := sdk.AccAddressFromBech32("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
-	suite.Require().NoError(err)
 
 	testCases := []struct {
 		name        string
@@ -25,7 +24,7 @@ func (suite *KeeperTestSuite) TestInvariants() {
 		expBroken   bool
 	}{
 		{
-			name:        "Empty state does not break invariants",
+			name:        "empty state does not break invariants",
 			expResponse: "Every invariant condition is fulfilled correctly",
 			expBroken:   false,
 		},
@@ -34,7 +33,7 @@ func (suite *KeeperTestSuite) TestInvariants() {
 			store: func(ctx sdk.Context) {
 				profile, err := types.NewProfileFromAccount(
 					"",
-					authtypes.NewBaseAccountWithAddress(address),
+					testutil.AccountFromAddr("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
 					time.Now(),
 				)
 				suite.Require().NoError(err)
@@ -113,7 +112,7 @@ func (suite *KeeperTestSuite) TestInvariants() {
 				pubKey := `{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A6jN4EPjj8mHf722yjEaKaGdJpxnTR40pDvXlX1mni9C"}`
 
 				var any codectypes.Any
-				err = suite.cdc.UnmarshalJSON([]byte(pubKey), &any)
+				err := suite.cdc.UnmarshalJSON([]byte(pubKey), &any)
 				suite.Require().NoError(err)
 
 				var key cryptotypes.PubKey
@@ -148,7 +147,7 @@ func (suite *KeeperTestSuite) TestInvariants() {
 				pubKey := `{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A6jN4EPjj8mHf722yjEaKaGdJpxnTR40pDvXlX1mni9C"}`
 
 				var any codectypes.Any
-				err = suite.cdc.UnmarshalJSON([]byte(pubKey), &any)
+				err := suite.cdc.UnmarshalJSON([]byte(pubKey), &any)
 				suite.Require().NoError(err)
 
 				var key cryptotypes.PubKey

--- a/x/profiles/keeper/keeper_app_links_test.go
+++ b/x/profiles/keeper/keeper_app_links_test.go
@@ -3,13 +3,15 @@ package keeper_test
 import (
 	"time"
 
+	"github.com/desmos-labs/desmos/testutil"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/desmos-labs/desmos/x/profiles/types"
 )
 
 func (suite *KeeperTestSuite) Test_SaveApplicationLink() {
-	usecases := []struct {
+	testCases := []struct {
 		name      string
 		store     func(ctx sdk.Context)
 		link      types.ApplicationLink
@@ -35,8 +37,8 @@ func (suite *KeeperTestSuite) Test_SaveApplicationLink() {
 		{
 			name: "correct requests returns no error",
 			store: func(ctx sdk.Context) {
-				profile := suite.CreateProfileFromAddress("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773")
-				suite.ak.SetAccount(ctx, profile)
+				profile := testutil.ProfileFromAddr("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773")
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
 			link: types.NewApplicationLink(
 				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
@@ -55,30 +57,30 @@ func (suite *KeeperTestSuite) Test_SaveApplicationLink() {
 		},
 	}
 
-	for _, uc := range usecases {
-		uc := uc
-		suite.Run(uc.name, func() {
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
-			if uc.store != nil {
-				uc.store(ctx)
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err := suite.k.SaveApplicationLink(ctx, uc.link)
-			if uc.shouldErr {
+			err := suite.k.SaveApplicationLink(ctx, tc.link)
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 
 				store := ctx.KVStore(suite.storeKey)
-				suite.Require().True(store.Has(types.UserApplicationLinkKey(uc.link.User, uc.link.Data.Application, uc.link.Data.Username)))
-				suite.Require().True(store.Has(types.ApplicationLinkClientIDKey(uc.link.OracleRequest.ClientID)))
+				suite.Require().True(store.Has(types.UserApplicationLinkKey(tc.link.User, tc.link.Data.Application, tc.link.Data.Username)))
+				suite.Require().True(store.Has(types.ApplicationLinkClientIDKey(tc.link.OracleRequest.ClientID)))
 			}
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) Test_GetApplicationLink() {
-	usecases := []struct {
+	testCases := []struct {
 		name        string
 		store       func(ctx sdk.Context)
 		user        string
@@ -105,7 +107,7 @@ func (suite *KeeperTestSuite) Test_GetApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -132,7 +134,7 @@ func (suite *KeeperTestSuite) Test_GetApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -159,7 +161,7 @@ func (suite *KeeperTestSuite) Test_GetApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -186,7 +188,7 @@ func (suite *KeeperTestSuite) Test_GetApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -210,27 +212,27 @@ func (suite *KeeperTestSuite) Test_GetApplicationLink() {
 		},
 	}
 
-	for _, uc := range usecases {
-		uc := uc
-		suite.Run(uc.name, func() {
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
-			if uc.store != nil {
-				uc.store(ctx)
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			link, found, err := suite.k.GetApplicationLink(ctx, uc.user, uc.application, uc.username)
-			suite.Require().Equal(uc.expFound, found)
+			link, found, err := suite.k.GetApplicationLink(ctx, tc.user, tc.application, tc.username)
+			suite.Require().Equal(tc.expFound, found)
 			suite.Require().NoError(err)
 
-			if uc.expFound {
-				suite.Require().Equal(uc.expLink, link)
+			if tc.expFound {
+				suite.Require().Equal(tc.expLink, link)
 			}
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) Test_GetApplicationLinkByClientID() {
-	usecases := []struct {
+	testCases := []struct {
 		name      string
 		store     func(ctx sdk.Context)
 		clientID  string
@@ -260,7 +262,7 @@ func (suite *KeeperTestSuite) Test_GetApplicationLinkByClientID() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
@@ -283,27 +285,27 @@ func (suite *KeeperTestSuite) Test_GetApplicationLinkByClientID() {
 		},
 	}
 
-	for _, uc := range usecases {
-		uc := uc
-		suite.Run(uc.name, func() {
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
-			if uc.store != nil {
-				uc.store(ctx)
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			link, err := suite.k.GetApplicationLinkByClientID(ctx, uc.clientID)
-			if uc.shouldErr {
+			link, err := suite.k.GetApplicationLinkByClientID(ctx, tc.clientID)
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(uc.expLink, link)
+				suite.Require().Equal(tc.expLink, link)
 			}
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) Test_DeleteApplicationLink() {
-	usecases := []struct {
+	testCases := []struct {
 		name        string
 		store       func(store sdk.Context)
 		user        string
@@ -329,7 +331,7 @@ func (suite *KeeperTestSuite) Test_DeleteApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -356,7 +358,7 @@ func (suite *KeeperTestSuite) Test_DeleteApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -383,7 +385,7 @@ func (suite *KeeperTestSuite) Test_DeleteApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -410,7 +412,7 @@ func (suite *KeeperTestSuite) Test_DeleteApplicationLink() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(address)))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -421,21 +423,21 @@ func (suite *KeeperTestSuite) Test_DeleteApplicationLink() {
 		},
 	}
 
-	for _, uc := range usecases {
-		uc := uc
-		suite.Run(uc.name, func() {
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
-			if uc.store != nil {
-				uc.store(ctx)
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err := suite.k.DeleteApplicationLink(ctx, uc.user, uc.application, uc.username)
-			if uc.shouldErr {
+			err := suite.k.DeleteApplicationLink(ctx, tc.user, tc.application, tc.username)
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 
-				_, found, err := suite.k.GetApplicationLink(ctx, uc.user, uc.application, uc.username)
+				_, found, err := suite.k.GetApplicationLink(ctx, tc.user, tc.application, tc.username)
 				suite.Require().NoError(err)
 				suite.Require().False(found)
 			}

--- a/x/profiles/keeper/keeper_blocks_test.go
+++ b/x/profiles/keeper/keeper_blocks_test.go
@@ -48,7 +48,7 @@ func (suite *KeeperTestSuite) TestKeeper_IsUserBlocked() {
 				tc.store(ctx)
 			}
 
-			res := suite.k.IsUserBlocked(suite.ctx, tc.blocker, tc.blocked)
+			res := suite.k.IsUserBlocked(ctx, tc.blocker, tc.blocked)
 			suite.Equal(tc.expBlocked, res)
 		})
 	}
@@ -85,6 +85,10 @@ func (suite *KeeperTestSuite) TestKeeper_SaveUserBlock() {
 		},
 		{
 			name: "user block added correctly",
+			store: func(ctx sdk.Context) {
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")))
+			},
 			userBlock: types.NewUserBlock(
 				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
@@ -113,7 +117,7 @@ func (suite *KeeperTestSuite) TestKeeper_SaveUserBlock() {
 				tc.store(ctx)
 			}
 
-			err := suite.k.SaveUserBlock(suite.ctx, tc.userBlock)
+			err := suite.k.SaveUserBlock(ctx, tc.userBlock)
 
 			if tc.shouldErr {
 				suite.Require().Error(err)
@@ -377,7 +381,7 @@ func (suite *KeeperTestSuite) TestKeeper_HasUserBlocked() {
 				tc.store(ctx)
 			}
 
-			blocked := suite.k.HasUserBlocked(suite.ctx, tc.blocker, tc.blocked, tc.subspace)
+			blocked := suite.k.HasUserBlocked(ctx, tc.blocker, tc.blocked, tc.subspace)
 			suite.Equal(tc.expBlocked, blocked)
 		})
 	}

--- a/x/profiles/keeper/keeper_blocks_test.go
+++ b/x/profiles/keeper/keeper_blocks_test.go
@@ -133,13 +133,13 @@ func (suite *KeeperTestSuite) TestKeeper_SaveUserBlock() {
 
 func (suite *KeeperTestSuite) TestKeeper_DeleteUserBlock() {
 	testCases := []struct {
-		name     string
-		store    func(ctx sdk.Context)
-		blocker  string
-		blocked  string
-		subspace string
-		expError bool
-		check    func(ctx sdk.Context)
+		name      string
+		store     func(ctx sdk.Context)
+		blocker   string
+		blocked   string
+		subspace  string
+		shouldErr bool
+		check     func(ctx sdk.Context)
 	}{
 		{
 			name: "delete user block with len(stored) > 1",
@@ -164,10 +164,10 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteUserBlock() {
 				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
 				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			blocker:  "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-			blocked:  "cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
-			subspace: "subspace",
-			expError: false,
+			blocker:   "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:   "cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+			subspace:  "subspace",
+			shouldErr: false,
 			check: func(ctx sdk.Context) {
 				blocks := suite.k.GetUserBlocks(ctx, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
 				suite.Require().Len(blocks, 1)
@@ -186,17 +186,17 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteUserBlock() {
 				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
 				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			blocker:  "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-			blocked:  "cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
-			subspace: "subspace",
-			expError: false,
+			blocker:   "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:   "cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+			subspace:  "subspace",
+			shouldErr: false,
 		},
 		{
-			name:     "deleting a user block that does not exist returns an error",
-			blocker:  "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-			blocked:  "blocked",
-			subspace: "subspace",
-			expError: true,
+			name:      "deleting a user block that does not exist returns an error",
+			blocker:   "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:   "blocked",
+			subspace:  "subspace",
+			shouldErr: true,
 		},
 	}
 
@@ -210,7 +210,7 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteUserBlock() {
 
 			err := suite.k.DeleteUserBlock(ctx, tc.blocker, tc.blocked, tc.subspace)
 
-			if tc.expError {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)

--- a/x/profiles/keeper/keeper_blocks_test.go
+++ b/x/profiles/keeper/keeper_blocks_test.go
@@ -1,376 +1,384 @@
 package keeper_test
 
-import "github.com/desmos-labs/desmos/x/profiles/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/desmos-labs/desmos/testutil"
+	"github.com/desmos-labs/desmos/x/profiles/types"
+)
 
 func (suite *KeeperTestSuite) TestKeeper_IsUserBlocked() {
-	tests := []struct {
+	testCases := []struct {
 		name       string
+		store      func(ctx sdk.Context)
 		blocker    string
 		blocked    string
-		userBlocks []types.UserBlock
-		expBool    bool
+		expBlocked bool
 	}{
 		{
-			name:    "blocked user found returns true",
-			blocker: suite.testData.user,
-			blocked: "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
-			userBlocks: []types.UserBlock{
-				types.NewUserBlock(
-					suite.testData.user,
+			name: "blocked user found returns true",
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 					"test",
 					"",
-				),
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			expBool: true,
+			blocker:    "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:    "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			expBlocked: true,
 		},
 		{
 			name:       "non blocked user not found returns false",
 			blocker:    "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 			blocked:    "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
-			userBlocks: nil,
-			expBool:    false,
+			expBlocked: false,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			if test.userBlocks != nil {
-				_ = suite.k.SaveUserBlock(suite.ctx, test.userBlocks[0])
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
-			res := suite.k.IsUserBlocked(suite.ctx, test.blocker, test.blocked)
-			suite.Equal(test.expBool, res)
+
+			res := suite.k.IsUserBlocked(suite.ctx, tc.blocker, tc.blocked)
+			suite.Equal(tc.expBlocked, res)
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestKeeper_SaveUserBlock() {
-	tests := []struct {
-		name             string
-		storedUserBlocks []types.UserBlock
-		userBlock        types.UserBlock
-		expErr           bool
-		expBlocks        []types.UserBlock
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		userBlock types.UserBlock
+		shouldErr bool
+		check     func(ctx sdk.Context)
 	}{
 		{
 			name: "already blocked user returns error",
-			storedUserBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace"),
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			userBlock: types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace"),
-			expErr:    true,
+			userBlock: types.NewUserBlock(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+				"reason",
+				"subspace",
+			),
+			shouldErr: true,
 		},
 		{
-			name:             "user block added correctly",
-			storedUserBlocks: nil,
-			userBlock:        types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace"),
-			expErr:           false,
-			expBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace"),
+			name: "user block added correctly",
+			userBlock: types.NewUserBlock(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"reason",
+				"subspace",
+			),
+			shouldErr: false,
+			check: func(ctx sdk.Context) {
+				blocks := suite.k.GetUserBlocks(ctx, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
+				suite.Require().Len(blocks, 1)
+				suite.Require().Equal(types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"reason",
+					"subspace",
+				), blocks[0])
 			},
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			for _, block := range test.storedUserBlocks {
-				err := suite.k.SaveUserBlock(suite.ctx, block)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err = suite.k.SaveUserBlock(suite.ctx, test.userBlock)
+			err := suite.k.SaveUserBlock(suite.ctx, tc.userBlock)
 
-			if test.expErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-
-				stored := suite.k.GetAllUsersBlocks(suite.ctx)
-				suite.Require().Equal(test.expBlocks, stored)
+				if tc.check != nil {
+					tc.check(ctx)
+				}
 			}
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestKeeper_DeleteUserBlock() {
-	tests := []struct {
-		name             string
-		storedUserBlocks []types.UserBlock
-		data             struct {
-			blocker  string
-			blocked  string
-			subspace string
-		}
-		expError  bool
-		expBlocks []types.UserBlock
+	testCases := []struct {
+		name     string
+		store    func(ctx sdk.Context)
+		blocker  string
+		blocked  string
+		subspace string
+		expError bool
+		check    func(ctx sdk.Context)
 	}{
 		{
 			name: "delete user block with len(stored) > 1",
-			storedUserBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "blocked", "reason", "subspace"),
-				types.NewUserBlock(suite.testData.user, "blocked_2", "reason", "subspace"),
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
+
+				block = types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			data: struct {
-				blocker  string
-				blocked  string
-				subspace string
-			}{
-				blocker:  suite.testData.user,
-				blocked:  "blocked",
-				subspace: "subspace",
-			},
-			expBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "blocked_2", "reason", "subspace"),
-			},
+			blocker:  "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:  "cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+			subspace: "subspace",
 			expError: false,
+			check: func(ctx sdk.Context) {
+				blocks := suite.k.GetUserBlocks(ctx, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")
+				suite.Require().Len(blocks, 1)
+			},
 		},
 		{
 			name: "delete user block with len(stored) == 1",
-			storedUserBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "blocked", "reason", "subspace"),
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			data: struct {
-				blocker  string
-				blocked  string
-				subspace string
-			}{
-				blocker:  suite.testData.user,
-				blocked:  "blocked",
-				subspace: "subspace",
-			},
+			blocker:  "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:  "cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+			subspace: "subspace",
 			expError: false,
 		},
 		{
-			name:             "deleting a user block that does not exist returns an error",
-			storedUserBlocks: nil,
-			data: struct {
-				blocker  string
-				blocked  string
-				subspace string
-			}{
-				blocker:  suite.testData.user,
-				blocked:  "blocked",
-				subspace: "subspace",
-			},
+			name:     "deleting a user block that does not exist returns an error",
+			blocker:  "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:  "blocked",
+			subspace: "subspace",
 			expError: true,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, block := range test.storedUserBlocks {
-				err := suite.k.SaveUserBlock(suite.ctx, block)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err = suite.k.DeleteUserBlock(suite.ctx, test.data.blocker, test.data.blocked, test.data.subspace)
+			err := suite.k.DeleteUserBlock(ctx, tc.blocker, tc.blocked, tc.subspace)
 
-			if test.expError {
+			if tc.expError {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-
-				blocks := suite.k.GetAllUsersBlocks(suite.ctx)
-				suite.Require().Equal(test.expBlocks, blocks)
+				if tc.check != nil {
+					tc.check(ctx)
+				}
 			}
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestKeeper_GetUserBlocks() {
-	tests := []struct {
-		name             string
-		storedUserBlocks []types.UserBlock
-		user             string
-		expUserBlocks    []types.UserBlock
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		user      string
+		expBlocks []types.UserBlock
 	}{
 		{
 			name: "non empty slice is returned properly",
-			storedUserBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "blocked", "reason", "subspace"),
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			user: suite.testData.user,
-			expUserBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "blocked", "reason", "subspace"),
+			user: "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			expBlocks: []types.UserBlock{
+				types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+					"reason",
+					"subspace",
+				),
 			},
 		},
 		{
-			name:             "empty slice is returned properly",
-			storedUserBlocks: nil,
-			user:             suite.testData.user,
-			expUserBlocks:    nil,
+			name:      "empty slice is returned properly",
+			user:      "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			expBlocks: nil,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, block := range test.storedUserBlocks {
-				err := suite.k.SaveUserBlock(suite.ctx, block)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			blocks := suite.k.GetUserBlocks(suite.ctx, test.user)
-			suite.Require().Equal(test.expUserBlocks, blocks)
+			blocks := suite.k.GetUserBlocks(ctx, tc.user)
+			suite.Require().Equal(tc.expBlocks, blocks)
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestKeeper_GetAllUsersBlocks() {
-	tests := []struct {
-		name              string
-		storedUsersBlocks []types.UserBlock
-		expUsersBlocks    []types.UserBlock
+	testCases := []struct {
+		name           string
+		store          func(ctx sdk.Context)
+		expUsersBlocks []types.UserBlock
 	}{
 		{
-			name: "Returns a non-empty users blocks slice",
-			storedUsersBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace_1"),
-				types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace_2"),
-				types.NewUserBlock(suite.testData.otherUser, "user_1", "reason", "subspace_1"),
-				types.NewUserBlock(suite.testData.otherUser, "user_1", "reason", "subspace_2"),
+			name: "non-empty users blocks list",
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
+
+				block = types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
 			expUsersBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace_1"),
-				types.NewUserBlock(suite.testData.user, "user_2", "reason", "subspace_2"),
-				types.NewUserBlock(suite.testData.otherUser, "user_1", "reason", "subspace_1"),
-				types.NewUserBlock(suite.testData.otherUser, "user_1", "reason", "subspace_2"),
+				types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"reason",
+					"subspace",
+				),
+				types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+					"reason",
+					"subspace",
+				),
 			},
+		},
+		{
+			name:           "empty users blocks list",
+			expUsersBlocks: nil,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, userBlock := range test.storedUsersBlocks {
-				err := suite.k.SaveUserBlock(suite.ctx, userBlock)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			actualBlocks := suite.k.GetAllUsersBlocks(suite.ctx)
-
-			suite.Require().Len(actualBlocks, len(test.expUsersBlocks))
-			for _, block := range test.expUsersBlocks {
-				suite.Require().Contains(actualBlocks, block)
-			}
+			blocks := suite.k.GetAllUsersBlocks(ctx)
+			suite.Require().Equal(tc.expUsersBlocks, blocks)
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestKeeper_HasUserBlocked() {
-	tests := []struct {
-		name         string
-		storedBlocks []types.UserBlock
-		data         struct {
-			blocker  string
-			blocked  string
-			subspace string
-		}
+	testCases := []struct {
+		name       string
+		store      func(ctx sdk.Context)
+		blocker    string
+		blocked    string
+		subspace   string
 		expBlocked bool
 	}{
 		{
 			name: "blocked user found returns true",
-			storedBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "blocked", "reason", "subspace"),
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"reason",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
-			data: struct {
-				blocker  string
-				blocked  string
-				subspace string
-			}{
-				blocker:  suite.testData.user,
-				blocked:  "blocked",
-				subspace: "subspace",
-			},
+			blocker:    "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:    "cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+			subspace:   "subspace",
 			expBlocked: true,
 		},
 		{
-			name: "blocked user not found returns false",
-			storedBlocks: []types.UserBlock{
-				types.NewUserBlock(suite.testData.user, "blocked", "reason", "subspace"),
-			},
-			data: struct {
-				blocker  string
-				blocked  string
-				subspace string
-			}{
-				blocker:  suite.testData.user,
-				blocked:  "blocked",
-				subspace: "subspace_2",
-			},
+			name:       "blocked user not found returns false",
+			blocker:    "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			blocked:    "blocked",
+			subspace:   "subspace_2",
 			expBlocked: false,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, block := range test.storedBlocks {
-				err := suite.k.SaveUserBlock(suite.ctx, block)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			blocked := suite.k.HasUserBlocked(suite.ctx, test.data.blocker, test.data.blocked, test.data.subspace)
-			suite.Equal(test.expBlocked, blocked)
+			blocked := suite.k.HasUserBlocked(suite.ctx, tc.blocker, tc.blocked, tc.subspace)
+			suite.Equal(tc.expBlocked, blocked)
 		})
 	}
 }

--- a/x/profiles/keeper/keeper_dtag_transfers.go
+++ b/x/profiles/keeper/keeper_dtag_transfers.go
@@ -20,7 +20,7 @@ func (k Keeper) SaveDTagTransferRequest(ctx sdk.Context, request types.DTagTrans
 	key := types.DTagTransferRequestStoreKey(request.Sender, request.Receiver)
 	if store.Has(key) {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest,
-			"the transfer request from %s to %s has already been made",
+			"the transfer request from %s to %s has already been created",
 			request.Sender, request.Receiver)
 	}
 

--- a/x/profiles/keeper/keeper_dtag_transfers_test.go
+++ b/x/profiles/keeper/keeper_dtag_transfers_test.go
@@ -62,11 +62,13 @@ func (suite *KeeperTestSuite) TestKeeper_SaveDTagTransferRequest() {
 				)
 				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
 				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
+
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn")))
 			},
 			transferReq: types.NewDTagTransferRequest(
 				"dtag",
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
-				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
 			),
 			shouldErr: false,
 			check: func(ctx sdk.Context) {
@@ -79,7 +81,7 @@ func (suite *KeeperTestSuite) TestKeeper_SaveDTagTransferRequest() {
 					types.NewDTagTransferRequest(
 						"dtag",
 						"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
-						"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+						"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
 					),
 				}
 				suite.Require().Equal(expected, suite.k.GetDTagTransferRequests(ctx))
@@ -95,20 +97,26 @@ func (suite *KeeperTestSuite) TestKeeper_SaveDTagTransferRequest() {
 				)
 				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
 				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
+
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn")))
 			},
-			transferReq: types.NewDTagTransferRequest("dtag", "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47", "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-			shouldErr:   false,
+			transferReq: types.NewDTagTransferRequest(
+				"dtag",
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+			),
+			shouldErr: false,
 			check: func(ctx sdk.Context) {
 				expected := []types.DTagTransferRequest{
 					types.NewDTagTransferRequest(
 						"dtag",
 						"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-						"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+						"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 					),
 					types.NewDTagTransferRequest(
 						"dtag",
 						"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
-						"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+						"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
 					),
 				}
 				suite.Require().Equal(expected, suite.k.GetDTagTransferRequests(ctx))

--- a/x/profiles/keeper/keeper_params_test.go
+++ b/x/profiles/keeper/keeper_params_test.go
@@ -22,6 +22,7 @@ func (suite *KeeperTestSuite) TestKeeper_GetParams() {
 	testCases := []struct {
 		name      string
 		store     func(ctx sdk.Context)
+		shouldErr bool
 		expParams types.Params
 	}{
 		{
@@ -34,6 +35,7 @@ func (suite *KeeperTestSuite) TestKeeper_GetParams() {
 				)
 				suite.k.SetParams(ctx, params)
 			},
+			shouldErr: false,
 			expParams: types.NewParams(
 				types.NewNicknameParams(sdk.NewInt(3), sdk.NewInt(1000)),
 				types.NewDTagParams("^[A-Za-z0-9_]+$", sdk.NewInt(3), sdk.NewInt(1000)),
@@ -41,7 +43,8 @@ func (suite *KeeperTestSuite) TestKeeper_GetParams() {
 			),
 		},
 		{
-			name:      "invalid params errors",
+			name:      "invalid params panics",
+			shouldErr: true,
 			expParams: types.Params{},
 		},
 	}
@@ -54,7 +57,11 @@ func (suite *KeeperTestSuite) TestKeeper_GetParams() {
 				tc.store(ctx)
 			}
 
-			suite.Require().Equal(tc.expParams, suite.k.GetParams(ctx))
+			if tc.shouldErr {
+				suite.Require().Panics(func() { suite.Require().Equal(tc.expParams, suite.k.GetParams(ctx)) })
+			} else {
+				suite.Require().NotPanics(func() { suite.Require().Equal(tc.expParams, suite.k.GetParams(ctx)) })
+			}
 		})
 	}
 }

--- a/x/profiles/keeper/keeper_params_test.go
+++ b/x/profiles/keeper/keeper_params_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func (suite *KeeperTestSuite) TestKeeper_SetParams() {
-	nicknameParams := types.NewNicknameParams(sdk.NewInt(3), sdk.NewInt(1000))
-	dtagParams := types.NewDTagParams("^[A-Za-z0-9_]+$", sdk.NewInt(3), sdk.NewInt(1000))
-
-	params := types.NewParams(nicknameParams, dtagParams, sdk.NewInt(1000))
+	params := types.NewParams(
+		types.NewNicknameParams(sdk.NewInt(3), sdk.NewInt(1000)),
+		types.NewDTagParams("^[A-Za-z0-9_]+$", sdk.NewInt(3), sdk.NewInt(1000)),
+		sdk.NewInt(1000),
+	)
 	suite.k.SetParams(suite.ctx, params)
 
 	actualParams := suite.k.GetParams(suite.ctx)
@@ -18,37 +19,42 @@ func (suite *KeeperTestSuite) TestKeeper_SetParams() {
 }
 
 func (suite *KeeperTestSuite) TestKeeper_GetParams() {
-	nicknameParams := types.NewNicknameParams(sdk.NewInt(3), sdk.NewInt(1000))
-	dtagParams := types.NewDTagParams("^[A-Za-z0-9_]+$", sdk.NewInt(3), sdk.NewInt(1000))
-	params := types.NewParams(nicknameParams, dtagParams, sdk.NewInt(1000))
-
-	tests := []struct {
+	testCases := []struct {
 		name      string
-		params    *types.Params
-		expParams *types.Params
+		store     func(ctx sdk.Context)
+		expParams types.Params
 	}{
 		{
-			name:      "Returning previously set params",
-			params:    &params,
-			expParams: &params,
+			name: "valid params do not error",
+			store: func(ctx sdk.Context) {
+				params := types.NewParams(
+					types.NewNicknameParams(sdk.NewInt(3), sdk.NewInt(1000)),
+					types.NewDTagParams("^[A-Za-z0-9_]+$", sdk.NewInt(3), sdk.NewInt(1000)),
+					sdk.NewInt(1000),
+				)
+				suite.k.SetParams(ctx, params)
+			},
+			expParams: types.NewParams(
+				types.NewNicknameParams(sdk.NewInt(3), sdk.NewInt(1000)),
+				types.NewDTagParams("^[A-Za-z0-9_]+$", sdk.NewInt(3), sdk.NewInt(1000)),
+				sdk.NewInt(1000),
+			),
 		},
 		{
-			name:      "Returning nothing",
-			params:    nil,
-			expParams: nil,
+			name:      "invalid params errors",
+			expParams: types.Params{},
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		suite.Run(test.name, func() {
-			if test.params != nil {
-				suite.k.SetParams(suite.ctx, *test.params)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			if test.expParams != nil {
-				suite.Require().Equal(*test.expParams, suite.k.GetParams(suite.ctx))
-			}
+			suite.Require().Equal(tc.expParams, suite.k.GetParams(ctx))
 		})
 	}
 }

--- a/x/profiles/keeper/keeper_relationships_test.go
+++ b/x/profiles/keeper/keeper_relationships_test.go
@@ -1,75 +1,109 @@
 package keeper_test
 
-import "github.com/desmos-labs/desmos/x/profiles/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/desmos-labs/desmos/testutil"
+	"github.com/desmos-labs/desmos/x/profiles/types"
+)
 
 func (suite *KeeperTestSuite) TestKeeper_SaveRelationship() {
-	tests := []struct {
-		name             string
-		stored           []types.Relationship
-		user             string
-		relationship     types.Relationship
-		expErr           bool
-		expRelationships []types.Relationship
+	testCases := []struct {
+		name         string
+		store        func(ctx sdk.Context)
+		relationship types.Relationship
+		shouldErr    bool
+		check        func(ctx sdk.Context)
 	}{
 		{
-			name: "already existent relationship returns error",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
+			name: "existent relationship returns error",
+			store: func(ctx sdk.Context) {
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
 			},
-			user:         suite.testData.user,
-			relationship: types.NewRelationship(suite.testData.user, "recipient", "subspace"),
-			expErr:       true,
+			relationship: types.NewRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"subspace",
+			),
+			shouldErr: true,
 		},
 		{
-			name:         "relationship added correctly",
-			stored:       nil,
-			user:         suite.testData.user,
-			relationship: types.NewRelationship(suite.testData.user, "recipient", "subspace"),
-			expErr:       false,
-			expRelationships: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
+			name: "relationship added correctly",
+			relationship: types.NewRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"subspace",
+			),
+			shouldErr: false,
+			check: func(ctx sdk.Context) {
+				expected := []types.Relationship{
+					types.NewRelationship(
+						"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+						"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+						"subspace",
+					),
+				}
+				suite.Require().Equal(expected, suite.k.GetAllRelationships(ctx))
 			},
 		},
 		{
-			name: "relationship added correctly (another subspace)",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
+			name: "relationship added correctly (different subspace)",
+			store: func(ctx sdk.Context) {
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
 			},
-			user:         suite.testData.user,
-			relationship: types.NewRelationship(suite.testData.user, "recipient", "subspace_2"),
-			expErr:       false,
+			relationship: types.NewRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"subspace_2",
+			),
+			shouldErr: false,
 		},
 		{
-			name: "relationship added correctly (another receiver)",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
+			name: "relationship added correctly (different receiver)",
+			store: func(ctx sdk.Context) {
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
 			},
-			user:         suite.testData.user,
-			relationship: types.NewRelationship(suite.testData.user, "user", "subspace"),
-			expErr:       false,
+			relationship: types.NewRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+				"subspace_2",
+			),
+			shouldErr: false,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, relationship := range test.stored {
-				err := suite.k.SaveRelationship(suite.ctx, relationship)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err = suite.k.SaveRelationship(suite.ctx, test.relationship)
+			err := suite.k.SaveRelationship(ctx, tc.relationship)
 
-			if test.expErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
@@ -79,176 +113,187 @@ func (suite *KeeperTestSuite) TestKeeper_SaveRelationship() {
 }
 
 func (suite *KeeperTestSuite) TestKeeper_GetAllRelationships() {
-	tests := []struct {
-		name     string
-		stored   []types.Relationship
-		expected []types.Relationship
+	testCases := []struct {
+		name             string
+		store            func(ctx sdk.Context)
+		expRelationships []types.Relationship
 	}{
 		{
 			name: "non empty relationships slice is returned properly",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
-				types.NewRelationship(suite.testData.user, "another_recipient", "subspace"),
-				types.NewRelationship(suite.testData.otherUser, "creator", "subspace"),
-				types.NewRelationship(suite.testData.otherUser, "creator", "subspace_2"),
+			store: func(ctx sdk.Context) {
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
+
+				relationship = types.NewRelationship(
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
 			},
-			expected: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
-				types.NewRelationship(suite.testData.user, "another_recipient", "subspace"),
-				types.NewRelationship(suite.testData.otherUser, "creator", "subspace"),
-				types.NewRelationship(suite.testData.otherUser, "creator", "subspace_2"),
+			expRelationships: []types.Relationship{
+				types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				),
+				types.NewRelationship(
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+					"subspace",
+				),
 			},
 		},
 		{
-			name:     "empty relationships slice is returned properly",
-			stored:   nil,
-			expected: []types.Relationship{},
+			name:             "empty relationships slice is returned properly",
+			expRelationships: []types.Relationship{},
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, rel := range test.stored {
-				err := suite.k.SaveRelationship(suite.ctx, rel)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			relationships := suite.k.GetAllRelationships(suite.ctx)
-
-			suite.Require().Len(relationships, len(test.expected))
-			for _, rel := range relationships {
-				suite.Require().Contains(test.expected, rel)
-			}
+			relationships := suite.k.GetAllRelationships(ctx)
+			suite.Require().Equal(tc.expRelationships, relationships)
 		})
 	}
-
 }
 
 func (suite *KeeperTestSuite) TestKeeper_GetUserRelationships() {
-	tests := []struct {
-		name     string
-		stored   []types.Relationship
-		user     string
-		expected []types.Relationship
+	testCases := []struct {
+		name             string
+		store            func(ctx sdk.Context)
+		user             string
+		expRelationships []types.Relationship
 	}{
 		{
-			name: "Returns non empty relationships slice",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "user_2", "subspace"),
-				types.NewRelationship(suite.testData.otherUser, "user_1", "subspace"),
+			name: "non empty relationships slice is returned properly",
+			store: func(ctx sdk.Context) {
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
 			},
-			user: suite.testData.user,
-			expected: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "user_2", "subspace"),
+			user: "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+			expRelationships: []types.Relationship{
+				types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				),
 			},
 		},
 		{
-			name:     "Returns empty relationships slice",
-			stored:   nil,
-			expected: nil,
+			name:             "empty relationships slice is returned properly",
+			expRelationships: nil,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, rel := range test.stored {
-				err := suite.k.SaveRelationship(suite.ctx, rel)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			relationships := suite.k.GetUserRelationships(suite.ctx, test.user)
-			suite.Require().Equal(test.expected, relationships)
+			relationships := suite.k.GetUserRelationships(ctx, tc.user)
+			suite.Require().Equal(tc.expRelationships, relationships)
 		})
 	}
 }
 
-func (suite *KeeperTestSuite) TestKeeper_DeleteRelationship() {
-	tests := []struct {
+func (suite *KeeperTestSuite) TestKeeper_RemoveRelationship() {
+	testCases := []struct {
 		name                 string
-		stored               []types.Relationship
+		store                func(ctx sdk.Context)
 		relationshipToDelete types.Relationship
-		expErr               bool
-		expRelationships     []types.Relationship
+		shouldErr            bool
+		check                func(ctx sdk.Context)
 	}{
 		{
-			name: "delete a relationship with len(relationships) > 1",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, suite.testData.otherUser, "subspace"),
-				types.NewRelationship(suite.testData.otherUser, "user_3", "subspace"),
-				types.NewRelationship(suite.testData.user, "user_3", "subspace"),
+			name: "deleting an existing relationship does not error",
+			store: func(ctx sdk.Context) {
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
+
+				relationship = types.NewRelationship(
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+					"subspace",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
 			},
-			relationshipToDelete: types.NewRelationship(suite.testData.otherUser, "user_3", "subspace"),
-			expErr:               false,
-			expRelationships: []types.Relationship{
-				types.NewRelationship(suite.testData.user, suite.testData.otherUser, "subspace"),
-				types.NewRelationship(suite.testData.user, "user_3", "subspace"),
+			relationshipToDelete: types.NewRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"subspace",
+			),
+			shouldErr: false,
+			check: func(ctx sdk.Context) {
+				expected := []types.Relationship{
+					types.NewRelationship(
+						"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+						"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
+						"subspace",
+					),
+				}
+				suite.Require().Equal(expected, suite.k.GetAllRelationships(ctx))
 			},
 		},
 		{
-			name: "delete a relationship with len(relationships) == 1",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "user_2", "subspace"),
-			},
-			relationshipToDelete: types.NewRelationship(suite.testData.user, "user_2", "subspace"),
-			expErr:               false,
-		},
-		{
-			name:                 "deleting a non existing relationship returns an error",
-			stored:               nil,
-			relationshipToDelete: types.NewRelationship(suite.testData.user, "user_2", "subspace"),
-			expErr:               true,
+			name: "deleting a non existing relationship returns an error",
+			relationshipToDelete: types.NewRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"subspace",
+			),
+			shouldErr: true,
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, rel := range test.stored {
-				err := suite.k.SaveRelationship(suite.ctx, rel)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err = suite.k.RemoveRelationship(suite.ctx, test.relationshipToDelete)
+			err := suite.k.RemoveRelationship(ctx, tc.relationshipToDelete)
 
-			if test.expErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-
-				rel := suite.k.GetAllRelationships(suite.ctx)
-				suite.Require().Equal(test.expRelationships, rel)
+				if tc.check != nil {
+					tc.check(ctx)
+				}
 			}
 		})
 	}

--- a/x/profiles/keeper/keeper_relationships_test.go
+++ b/x/profiles/keeper/keeper_relationships_test.go
@@ -36,6 +36,10 @@ func (suite *KeeperTestSuite) TestKeeper_SaveRelationship() {
 		},
 		{
 			name: "relationship added correctly",
+			store: func(ctx sdk.Context) {
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")))
+			},
 			relationship: types.NewRelationship(
 				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
@@ -141,20 +145,20 @@ func (suite *KeeperTestSuite) TestKeeper_GetAllRelationships() {
 			},
 			expRelationships: []types.Relationship{
 				types.NewRelationship(
-					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
 					"subspace",
 				),
 				types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
-					"cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn",
 					"subspace",
 				),
 			},
 		},
 		{
 			name:             "empty relationships slice is returned properly",
-			expRelationships: []types.Relationship{},
+			expRelationships: nil,
 		},
 	}
 

--- a/x/profiles/keeper/msg_server_blocks_test.go
+++ b/x/profiles/keeper/msg_server_blocks_test.go
@@ -105,7 +105,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UnblockUser() {
 		name      string
 		store     func(ctx sdk.Context)
 		msg       *types.MsgUnblockUser
-		expErr    bool
+		shouldErr bool
 		expEvents sdk.Events
 		check     func(ctx sdk.Context)
 	}{
@@ -116,7 +116,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UnblockUser() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"subspace",
 			),
-			expErr: true,
+			shouldErr: true,
 		},
 		{
 			name: "existing block is removed properly",
@@ -136,7 +136,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UnblockUser() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
-			expErr: false,
+			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeUnblockUser,
@@ -162,7 +162,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UnblockUser() {
 			service := keeper.NewMsgServerImpl(suite.k)
 			_, err := service.UnblockUser(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if tc.expErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)

--- a/x/profiles/keeper/msg_server_blocks_test.go
+++ b/x/profiles/keeper/msg_server_blocks_test.go
@@ -41,6 +41,10 @@ func (suite *KeeperTestSuite) TestMsgServer_BlockUser() {
 		},
 		{
 			name: "non existing block is stored correctly",
+			store: func(ctx sdk.Context) {
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")))
+			},
 			msg: types.NewMsgBlockUser(
 				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
@@ -130,15 +134,15 @@ func (suite *KeeperTestSuite) TestMsgServer_UnblockUser() {
 			msg: types.NewMsgUnblockUser(
 				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
-				"subspace",
+				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
 			expErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeUnblockUser,
 					sdk.NewAttribute(types.AttributeKeyUserBlockBlocker, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-					sdk.NewAttribute(types.AttributeKeyUserBlockBlocked, "blocked"),
-					sdk.NewAttribute(types.AttributeKeySubspace, "subspace"),
+					sdk.NewAttribute(types.AttributeKeyUserBlockBlocked, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
+					sdk.NewAttribute(types.AttributeKeySubspace, "4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e"),
 				),
 			},
 			check: func(ctx sdk.Context) {

--- a/x/profiles/keeper/msg_server_dtag_transfers_test.go
+++ b/x/profiles/keeper/msg_server_dtag_transfers_test.go
@@ -3,370 +3,390 @@ package keeper_test
 import (
 	"fmt"
 
+	"github.com/desmos-labs/desmos/testutil"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/desmos-labs/desmos/x/profiles/keeper"
 	"github.com/desmos-labs/desmos/x/profiles/types"
 )
 
-func (suite *KeeperTestSuite) Test_handleMsgRequestDTagTransfer() {
-	tests := []struct {
-		name           string
-		storedDTagReqs []types.DTagTransferRequest
-		storedBlocks   []types.UserBlock
-		msg            *types.MsgRequestDTagTransfer
-		shouldErr      bool
-		expEvents      sdk.Events
+func (suite *KeeperTestSuite) TestMsgServer_RequestDTagTransfer() {
+	testCases := []struct {
+		name         string
+		store        func(ctx sdk.Context)
+		storedBlocks []types.UserBlock
+		msg          *types.MsgRequestDTagTransfer
+		shouldErr    bool
+		expEvents    sdk.Events
 	}{
 		{
-			name: "Blocked receiver making request returns error",
-			storedBlocks: []types.UserBlock{
-				types.NewUserBlock(
-					suite.testData.otherUser,
-					suite.testData.user,
+			name: "blocked receiver making request returns error",
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
 					"This user has been blocked",
 					"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-				),
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
+
 			},
-			msg:       types.NewMsgRequestDTagTransfer(suite.testData.user, suite.testData.otherUser),
-			expEvents: sdk.EmptyEvents(),
+			msg: types.NewMsgRequestDTagTransfer(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			shouldErr: true,
 		},
 		{
-			name:      "No DTag to transfer returns error",
-			msg:       types.NewMsgRequestDTagTransfer(suite.testData.otherUser, "user"),
-			expEvents: sdk.EmptyEvents(),
+			name: "no DTag to transfer returns error",
+			msg: types.NewMsgRequestDTagTransfer(
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			shouldErr: true,
 		},
 		{
 			name: "Already present request returns error",
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
+			store: func(ctx sdk.Context) {
+				request := types.NewDTagTransferRequest(
+					"dtag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
+				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
 			},
-			msg:       types.NewMsgRequestDTagTransfer(suite.testData.user, suite.testData.otherUser),
-			expEvents: sdk.EmptyEvents(),
+			msg: types.NewMsgRequestDTagTransfer(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			shouldErr: true,
 		},
 		{
-			name:      "Not already present request saved correctly",
-			msg:       types.NewMsgRequestDTagTransfer(suite.testData.user, suite.testData.otherUser),
+			name: "not already present request is saved correctly",
+			msg: types.NewMsgRequestDTagTransfer(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeDTagTransferRequest,
-					sdk.NewAttribute(types.AttributeDTagToTrade, fmt.Sprintf("%s-dtag", suite.testData.otherUser)),
-					sdk.NewAttribute(types.AttributeRequestSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRequestReceiver, suite.testData.otherUser),
+					sdk.NewAttribute(types.AttributeDTagToTrade, fmt.Sprintf("%s-dtag", "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")),
+					sdk.NewAttribute(types.AttributeRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
+					sdk.NewAttribute(types.AttributeRequestReceiver, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
 				),
 			},
 		},
 	}
 
-	for _, test := range tests {
-		suite.Run(test.name, func() {
-			suite.SetupTest()
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, req := range test.storedDTagReqs {
-				err := suite.k.SaveDTagTransferRequest(suite.ctx, req)
-				suite.Require().NoError(err)
-			}
-
-			for _, block := range test.storedBlocks {
-				err := suite.k.SaveUserBlock(suite.ctx, block)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
 			server := keeper.NewMsgServerImpl(suite.k)
-			_, err = server.RequestDTagTransfer(sdk.WrapSDKContext(suite.ctx), test.msg)
+			_, err := server.RequestDTagTransfer(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if test.shouldErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 			}
 		})
 	}
 }
 
-func (suite *KeeperTestSuite) Test_handleMsgAcceptDTagTransfer() {
-	otherAddr, err := sdk.AccAddressFromBech32(suite.testData.otherUser)
-	suite.Require().NoError(err)
-
-	newAddr, err := sdk.AccAddressFromBech32("cosmos1lkqrqrns0ekttzrs678thh5f4prcgasthqcxph")
-	suite.Require().NoError(err)
-
-	tests := []struct {
-		name           string
-		storedDTagReqs []types.DTagTransferRequest
-		storedProfiles []*types.Profile
-		msg            *types.MsgAcceptDTagTransfer
-		shouldErr      bool
-		expEvents      sdk.Events
+func (suite *KeeperTestSuite) TestMsgServer_CancelDTagTransfer() {
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		msg       *types.MsgCancelDTagTransfer
+		shouldErr bool
+		expEvents sdk.Events
 	}{
 		{
-			name:      "No request made from the receiving user returns error",
-			msg:       types.NewMsgAcceptDTagTransfer("newDtag", suite.testData.user, suite.testData.otherUser),
+			name:      "request not found returns error",
+			msg:       types.NewMsgCancelDTagTransferRequest("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47", "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
 			expEvents: sdk.EmptyEvents(),
 			shouldErr: true,
 		},
 		{
-			name: "Return an error if the request receiver does not have a profile",
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
+			name: "found request is cancelled correctly",
+			store: func(ctx sdk.Context) {
+				request := types.NewDTagTransferRequest(
+					"dtag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
+				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
 			},
-			msg:       types.NewMsgAcceptDTagTransfer("newDtag", suite.testData.user, suite.testData.otherUser),
+			msg: types.NewMsgCancelDTagTransferRequest(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
+			shouldErr: false,
+			expEvents: sdk.Events{
+				sdk.NewEvent(
+					types.EventTypeDTagTransferCancel,
+					sdk.NewAttribute(types.AttributeRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
+					sdk.NewAttribute(types.AttributeRequestReceiver, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
+				),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
+			}
+
+			server := keeper.NewMsgServerImpl(suite.k)
+			_, err := server.CancelDTagTransfer(sdk.WrapSDKContext(ctx), tc.msg)
+
+			if tc.shouldErr {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
+			}
+		})
+	}
+}
+
+func (suite *KeeperTestSuite) TestMsgServer_AcceptDTagTransfer() {
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		msg       *types.MsgAcceptDTagTransfer
+		shouldErr bool
+		expEvents sdk.Events
+	}{
+		{
+			name: "returns an error if there are no request made from the receiving user",
+			msg: types.NewMsgAcceptDTagTransfer(
+				"newDtag",
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			expEvents: sdk.EmptyEvents(),
 			shouldErr: true,
 		},
 		{
-			name: "Return an error if the new DTag has already been chosen by another user",
-			storedProfiles: []*types.Profile{
-				suite.CheckProfileNoError(
-					types.NewProfileFromAccount("dtag", authtypes.NewBaseAccountWithAddress(otherAddr), suite.ctx.BlockTime()),
-				),
-				suite.CheckProfileNoError(
-					types.NewProfileFromAccount("newDtag", authtypes.NewBaseAccountWithAddress(newAddr), suite.ctx.BlockTime()),
-				),
+			name: "returns an error if the request receiver does not have a profile",
+			store: func(ctx sdk.Context) {
+				store := suite.ctx.KVStore(suite.storeKey)
+				request := types.NewDTagTransferRequest(
+					"dtag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+				store.Set(
+					types.DTagTransferRequestStoreKey(request.Sender, request.Receiver),
+					suite.cdc.MustMarshalBinaryBare(&request),
+				)
 			},
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
+			msg: types.NewMsgAcceptDTagTransfer(
+				"newDtag",
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
+			shouldErr: true,
+		},
+		{
+			name: "returns an error if the new DTag has already been chosen by another user",
+			store: func(ctx sdk.Context) {
+				request := types.NewDTagTransferRequest(
+					"dtag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Sender)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
+				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
+
+				profile := testutil.ProfileFromAddr("cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn")
+				profile.DTag = "NewDTag"
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
-			msg:       types.NewMsgAcceptDTagTransfer("newDtag", suite.testData.user, suite.testData.otherUser),
+			msg: types.NewMsgAcceptDTagTransfer(
+				"newDtag",
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
+			shouldErr: true,
+		},
+		{
+			name: "returns an error when current owner DTag is different from the requested one",
+			store: func(ctx sdk.Context) {
+				request := types.NewDTagTransferRequest(
+					"dtag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Sender)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
+				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
+
+				profile := testutil.ProfileFromAddr("cosmos1xcy3els9ua75kdm783c3qu0rfa2eplesldfevn")
+				profile.DTag = "dtag"
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
+			},
+			msg: types.NewMsgAcceptDTagTransfer(
+				"NewDTag",
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			expEvents: sdk.EmptyEvents(),
 			shouldErr: true,
 		},
 		{
-			name: "Return an error when current owner DTag is different from the requested one",
-			storedProfiles: []*types.Profile{
-				suite.CheckProfileNoError(
-					types.NewProfileFromAccount("dtag1", authtypes.NewBaseAccountWithAddress(otherAddr), suite.ctx.BlockTime()),
-				),
+			name: "DTag is exchanged correctly (not existent sender profile)",
+			store: func(ctx sdk.Context) {
+				request := types.NewDTagTransferRequest(
+					"DTag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
+				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
 			},
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
-			},
-			msg:       types.NewMsgAcceptDTagTransfer("newDtag", suite.testData.user, suite.testData.otherUser),
-			expEvents: sdk.EmptyEvents(),
-			shouldErr: true,
-		},
-		{
-			name: "DTag exchanged correctly (not existent sender profile)",
-			storedProfiles: []*types.Profile{
-				suite.CheckProfileNoError(
-					types.NewProfileFromAccount("dtag", authtypes.NewBaseAccountWithAddress(otherAddr), suite.ctx.BlockTime()),
-				),
-			},
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
-			},
-			msg:       types.NewMsgAcceptDTagTransfer("newDtag", suite.testData.user, suite.testData.otherUser),
+			msg: types.NewMsgAcceptDTagTransfer(
+				"NewDtag",
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeDTagTransferAccept,
-					sdk.NewAttribute(types.AttributeDTagToTrade, "dtag"),
-					sdk.NewAttribute(types.AttributeNewDTag, "newDtag"),
-					sdk.NewAttribute(types.AttributeRequestSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRequestReceiver, suite.testData.otherUser),
+					sdk.NewAttribute(types.AttributeDTagToTrade, "DTag"),
+					sdk.NewAttribute(types.AttributeNewDTag, "NewDtag"),
+					sdk.NewAttribute(types.AttributeRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
+					sdk.NewAttribute(types.AttributeRequestReceiver, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
 				),
 			},
 		},
 		{
 			name: "DTag exchanged correctly (already existent sender profile)",
-			storedProfiles: []*types.Profile{
-				suite.CheckProfileNoError(
-					types.NewProfileFromAccount("dtag", suite.testData.profile.GetAccount(), suite.ctx.BlockTime()),
-				),
-				suite.CheckProfileNoError(
-					types.NewProfileFromAccount("previous", authtypes.NewBaseAccountWithAddress(otherAddr), suite.ctx.BlockTime()),
-				),
+			store: func(ctx sdk.Context) {
+				request := types.NewDTagTransferRequest(
+					"DTag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Sender)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
+				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
 			},
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("previous", suite.testData.user, suite.testData.otherUser),
-			},
-			msg: types.NewMsgAcceptDTagTransfer("newDtag", suite.testData.user, suite.testData.otherUser),
+			msg: types.NewMsgAcceptDTagTransfer(
+				"NewDtag",
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeDTagTransferAccept,
-					sdk.NewAttribute(types.AttributeDTagToTrade, "previous"),
-					sdk.NewAttribute(types.AttributeNewDTag, "newDtag"),
-					sdk.NewAttribute(types.AttributeRequestSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRequestReceiver, suite.testData.otherUser),
+					sdk.NewAttribute(types.AttributeDTagToTrade, "DTag"),
+					sdk.NewAttribute(types.AttributeNewDTag, "NewDtag"),
+					sdk.NewAttribute(types.AttributeRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
+					sdk.NewAttribute(types.AttributeRequestReceiver, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
 				),
 			},
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err = suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			suite.k.SetParams(suite.ctx, types.DefaultParams())
-
-			for _, prof := range test.storedProfiles {
-				err := suite.k.StoreProfile(suite.ctx, prof)
-				suite.Require().NoError(err)
-			}
-
-			for _, req := range test.storedDTagReqs {
-				err := suite.k.SaveDTagTransferRequest(suite.ctx, req)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
 			server := keeper.NewMsgServerImpl(suite.k)
-			_, err = server.AcceptDTagTransfer(sdk.WrapSDKContext(suite.ctx), test.msg)
+			_, err := server.AcceptDTagTransfer(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if test.shouldErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 			}
 		})
 	}
 }
 
-func (suite *KeeperTestSuite) Test_handleMsgRefuseDTagRequest() {
-	tests := []struct {
-		name           string
-		msg            *types.MsgRefuseDTagTransfer
-		storedDTagReqs []types.DTagTransferRequest
-		shouldErr      bool
-		expEvents      sdk.Events
+func (suite *KeeperTestSuite) TestMsgServer_RefuseDTagTransfer() {
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		msg       *types.MsgRefuseDTagTransfer
+		shouldErr bool
+		expEvents sdk.Events
 	}{
 		{
-			name:           "No requests found returns error",
-			storedDTagReqs: nil,
-			msg:            types.NewMsgRefuseDTagTransferRequest(suite.testData.user, suite.testData.otherUser),
-			expEvents:      sdk.EmptyEvents(),
-			shouldErr:      true,
+			name: "not found request returns error",
+			msg: types.NewMsgRefuseDTagTransferRequest(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
+			shouldErr: true,
 		},
 		{
-			name: "Deletion runs correctly",
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
+			name: "found request is refused correctly",
+			store: func(ctx sdk.Context) {
+				request := types.NewDTagTransferRequest(
+					"dtag",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(request.Receiver)))
+				suite.Require().NoError(suite.k.SaveDTagTransferRequest(ctx, request))
 			},
-			msg:       types.NewMsgRefuseDTagTransferRequest(suite.testData.user, suite.testData.otherUser),
+			msg: types.NewMsgRefuseDTagTransferRequest(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+			),
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeDTagTransferRefuse,
-					sdk.NewAttribute(types.AttributeRequestSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRequestReceiver, suite.testData.otherUser),
+					sdk.NewAttribute(types.AttributeRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
+					sdk.NewAttribute(types.AttributeRequestReceiver, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
 				),
 			},
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, req := range test.storedDTagReqs {
-				err := suite.k.SaveDTagTransferRequest(suite.ctx, req)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
 			server := keeper.NewMsgServerImpl(suite.k)
-			_, err = server.RefuseDTagTransfer(sdk.WrapSDKContext(suite.ctx), test.msg)
+			_, err := server.RefuseDTagTransfer(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if test.shouldErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
-			}
-		})
-	}
-}
-
-func (suite *KeeperTestSuite) Test_handleMsgCancelDTagRequest() {
-	tests := []struct {
-		name           string
-		msg            *types.MsgCancelDTagTransfer
-		storedDTagReqs []types.DTagTransferRequest
-		shouldErr      bool
-		expEvents      sdk.Events
-	}{
-		{
-			name:           "No requests found returns error",
-			storedDTagReqs: nil,
-			msg:            types.NewMsgCancelDTagTransferRequest(suite.testData.user, suite.testData.otherUser),
-			expEvents:      sdk.EmptyEvents(),
-			shouldErr:      true,
-		},
-		{
-			name: "Deletion runs correctly",
-			storedDTagReqs: []types.DTagTransferRequest{
-				types.NewDTagTransferRequest("dtag", suite.testData.user, suite.testData.otherUser),
-			},
-			msg:       types.NewMsgCancelDTagTransferRequest(suite.testData.user, suite.testData.otherUser),
-			shouldErr: false,
-			expEvents: sdk.Events{
-				sdk.NewEvent(
-					types.EventTypeDTagTransferCancel,
-					sdk.NewAttribute(types.AttributeRequestSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRequestReceiver, suite.testData.otherUser),
-				),
-			},
-		},
-	}
-
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, req := range test.storedDTagReqs {
-				err := suite.k.SaveDTagTransferRequest(suite.ctx, req)
-				suite.Require().NoError(err)
-			}
-
-			server := keeper.NewMsgServerImpl(suite.k)
-			_, err = server.CancelDTagTransfer(sdk.WrapSDKContext(suite.ctx), test.msg)
-
-			if test.shouldErr {
-				suite.Require().Error(err)
-			} else {
-				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 			}
 		})
 	}

--- a/x/profiles/keeper/msg_server_relationships_test.go
+++ b/x/profiles/keeper/msg_server_relationships_test.go
@@ -3,199 +3,190 @@ package keeper_test
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/desmos-labs/desmos/testutil"
+
 	"github.com/desmos-labs/desmos/x/profiles/keeper"
 	"github.com/desmos-labs/desmos/x/profiles/types"
 )
 
-func (suite *KeeperTestSuite) Test_handleMsgCreateRelationship() {
-	tests := []struct {
-		name                string
-		storedBlock         []types.UserBlock
-		storedRelationships []types.Relationship
-		msg                 *types.MsgCreateRelationship
-		expErr              bool
-		expEvents           sdk.Events
-		expRelationships    []types.Relationship
+func (suite *KeeperTestSuite) TestMsgServer_CreateRelationship() {
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		msg       *types.MsgCreateRelationship
+		expErr    bool
+		expEvents sdk.Events
+		check     func(ctx sdk.Context)
 	}{
 		{
-			name: "Relationship sender blocked by receiver returns error",
-			storedBlock: []types.UserBlock{
-				types.NewUserBlock(
-					suite.testData.otherUser,
-					suite.testData.user,
-					"test",
+			name: "returns an error if the relationship sender is blocked by the receiver",
+			store: func(ctx sdk.Context) {
+				block := types.NewUserBlock(
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"tc",
 					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
-				),
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocker)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(block.Blocked)))
+				suite.Require().NoError(suite.k.SaveUserBlock(ctx, block))
 			},
 			msg: types.NewMsgCreateRelationship(
-				suite.testData.user,
-				suite.testData.otherUser,
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
 			expErr: true,
 		},
 		{
-			name: "Existing relationship returns error",
-			storedRelationships: []types.Relationship{
-				types.NewRelationship(
-					suite.testData.user,
-					suite.testData.otherUser,
+			name: "existing relationship returns error",
+			store: func(ctx sdk.Context) {
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
-				),
+				)
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Creator)))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr(relationship.Recipient)))
+				suite.Require().NoError(suite.k.SaveRelationship(ctx, relationship))
 			},
 			msg: types.NewMsgCreateRelationship(
-				suite.testData.user,
-				suite.testData.otherUser,
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
 			expErr: true,
 		},
 		{
-			name: "Relationship has been saved correctly",
+			name: "new relationship is stored correctly",
+			store: func(ctx sdk.Context) {
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47")))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, testutil.ProfileFromAddr("cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")))
+			},
 			msg: types.NewMsgCreateRelationship(
-				suite.testData.user,
-				suite.testData.otherUser,
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
 			expErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeRelationshipCreated,
-					sdk.NewAttribute(types.AttributeRelationshipSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRelationshipReceiver, suite.testData.otherUser),
+					sdk.NewAttribute(types.AttributeRelationshipSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
+					sdk.NewAttribute(types.AttributeRelationshipReceiver, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
 					sdk.NewAttribute(types.AttributeRelationshipSubspace, "4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e"),
 				),
 			},
-			expRelationships: []types.Relationship{
-				types.NewRelationship(
-					suite.testData.user,
-					suite.testData.otherUser,
-					"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
-				),
+			check: func(ctx sdk.Context) {
+				expected := []types.Relationship{
+					types.NewRelationship(
+						"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+						"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
+						"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
+					),
+				}
+				suite.Require().Equal(expected, suite.k.GetAllRelationships(ctx))
 			},
 		},
 	}
 
-	for _, test := range tests {
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-			otherProfile := suite.CreateProfileFromAddress(suite.testData.otherUser)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			err = suite.k.StoreProfile(suite.ctx, otherProfile)
-			suite.Require().NoError(err)
-
-			for _, rel := range test.storedRelationships {
-				err := suite.k.SaveRelationship(suite.ctx, rel)
-				suite.Require().NoError(err)
-			}
-
-			for _, block := range test.storedBlock {
-				err := suite.k.SaveUserBlock(suite.ctx, block)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
 			handler := keeper.NewMsgServerImpl(suite.k)
-			_, err = handler.CreateRelationship(sdk.WrapSDKContext(suite.ctx), test.msg)
+			_, err := handler.CreateRelationship(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if test.expErr {
+			if tc.expErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 
-				stored := suite.k.GetAllRelationships(suite.ctx)
-				suite.Require().Equal(test.expRelationships, stored)
+				if tc.store != nil {
+					tc.store(ctx)
+				}
 			}
 		})
 	}
 }
 
-func (suite *KeeperTestSuite) Test_handleMsgDeleteRelationship() {
-	tests := []struct {
-		name             string
-		stored           []types.Relationship
-		msg              *types.MsgDeleteRelationship
-		expErr           bool
-		expEvents        sdk.Events
-		expRelationships []types.Relationship
+func (suite *KeeperTestSuite) TestMsgServer_DeleteRelationship() {
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		msg       *types.MsgDeleteRelationship
+		expErr    bool
+		expEvents sdk.Events
+		check     func(ctx sdk.Context)
 	}{
 		{
-			name: "Relationship not found returns error",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
-			},
-			msg:    types.NewMsgDeleteRelationship(suite.testData.user, "recipient", "other_subspace"),
+			name: "non existing relationship returns error",
+			msg: types.NewMsgDeleteRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"other_subspace",
+			),
 			expErr: true,
 		},
 		{
-			name: "Existing relationship is removed properly and leaves empty array",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
+			name: "existing relationship is removed properly",
+			store: func(ctx sdk.Context) {
+				store := ctx.KVStore(suite.storeKey)
+				relationship := types.NewRelationship(
+					"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+					"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+					"subspace",
+				)
+				store.Set(
+					types.RelationshipsStoreKey(relationship.Creator, relationship.Subspace, relationship.Recipient),
+					suite.cdc.MustMarshalBinaryBare(&relationship),
+				)
 			},
-			msg:    types.NewMsgDeleteRelationship(suite.testData.user, "recipient", "subspace"),
+			msg: types.NewMsgDeleteRelationship(
+				"cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47",
+				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
+				"subspace",
+			),
 			expErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeRelationshipsDeleted,
-					sdk.NewAttribute(types.AttributeRelationshipSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRelationshipReceiver, "recipient"),
+					sdk.NewAttribute(types.AttributeRelationshipSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
+					sdk.NewAttribute(types.AttributeRelationshipReceiver, "cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x"),
 					sdk.NewAttribute(types.AttributeRelationshipSubspace, "subspace"),
 				),
 			},
-		},
-		{
-			name: "Existing relationship is removed properly and leaves not empty array",
-			stored: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "subspace"),
-				types.NewRelationship(suite.testData.user, "recipient", "other_subspace"),
-			},
-			msg:    types.NewMsgDeleteRelationship(suite.testData.user, "recipient", "subspace"),
-			expErr: false,
-			expEvents: sdk.Events{
-				sdk.NewEvent(
-					types.EventTypeRelationshipsDeleted,
-					sdk.NewAttribute(types.AttributeRelationshipSender, suite.testData.user),
-					sdk.NewAttribute(types.AttributeRelationshipReceiver, "recipient"),
-					sdk.NewAttribute(types.AttributeRelationshipSubspace, "subspace"),
-				),
-			},
-			expRelationships: []types.Relationship{
-				types.NewRelationship(suite.testData.user, "recipient", "other_subspace"),
+			check: func(ctx sdk.Context) {
+				suite.Require().Empty(suite.k.GetAllRelationships(ctx))
 			},
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		suite.SetupTest()
-		suite.Run(test.name, func() {
-
-			profile := suite.CreateProfileFromAddress(suite.testData.user)
-
-			err := suite.k.StoreProfile(suite.ctx, profile)
-			suite.Require().NoError(err)
-
-			for _, relationship := range test.stored {
-				err := suite.k.SaveRelationship(suite.ctx, relationship)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
 			service := keeper.NewMsgServerImpl(suite.k)
-			_, err = service.DeleteRelationship(sdk.WrapSDKContext(suite.ctx), test.msg)
+			_, err := service.DeleteRelationship(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if test.expErr {
+			if tc.expErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 
-				left := suite.k.GetAllRelationships(suite.ctx)
-				suite.Require().Equal(test.expRelationships, left)
+				if tc.check != nil {
+					tc.check(ctx)
+				}
 			}
 		})
 	}

--- a/x/profiles/keeper/msg_server_relationships_test.go
+++ b/x/profiles/keeper/msg_server_relationships_test.go
@@ -14,7 +14,7 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateRelationship() {
 		name      string
 		store     func(ctx sdk.Context)
 		msg       *types.MsgCreateRelationship
-		expErr    bool
+		shouldErr bool
 		expEvents sdk.Events
 		check     func(ctx sdk.Context)
 	}{
@@ -36,7 +36,7 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateRelationship() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
-			expErr: true,
+			shouldErr: true,
 		},
 		{
 			name: "existing relationship returns error",
@@ -55,7 +55,7 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateRelationship() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
-			expErr: true,
+			shouldErr: true,
 		},
 		{
 			name: "new relationship is stored correctly",
@@ -68,7 +68,7 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateRelationship() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 				"4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cccb81494b36e",
 			),
-			expErr: false,
+			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeRelationshipCreated,
@@ -101,14 +101,14 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateRelationship() {
 			handler := keeper.NewMsgServerImpl(suite.k)
 			_, err := handler.CreateRelationship(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if tc.expErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 
-				if tc.store != nil {
-					tc.store(ctx)
+				if tc.check != nil {
+					tc.check(ctx)
 				}
 			}
 		})
@@ -120,7 +120,7 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteRelationship() {
 		name      string
 		store     func(ctx sdk.Context)
 		msg       *types.MsgDeleteRelationship
-		expErr    bool
+		shouldErr bool
 		expEvents sdk.Events
 		check     func(ctx sdk.Context)
 	}{
@@ -131,7 +131,7 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteRelationship() {
 				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
 				"other_subspace",
 			),
-			expErr: true,
+			shouldErr: true,
 		},
 		{
 			name: "existing relationship is removed properly",
@@ -152,7 +152,7 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteRelationship() {
 				"cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x",
 				"subspace",
 			),
-			expErr: false,
+			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeRelationshipsDeleted,
@@ -178,7 +178,7 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteRelationship() {
 			service := keeper.NewMsgServerImpl(suite.k)
 			_, err := service.DeleteRelationship(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if tc.expErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)

--- a/x/profiles/keeper/msgs_server_profile_test.go
+++ b/x/profiles/keeper/msgs_server_profile_test.go
@@ -214,13 +214,13 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteProfile() {
 		name      string
 		store     func(ctx sdk.Context)
 		msg       *types.MsgDeleteProfile
-		expErr    bool
+		shouldErr bool
 		expEvents sdk.Events
 	}{
 		{
 			name:      "non existent profile returns error",
 			msg:       types.NewMsgDeleteProfile("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
-			expErr:    true,
+			shouldErr: true,
 			expEvents: sdk.EmptyEvents(),
 		},
 		{
@@ -229,8 +229,8 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteProfile() {
 				profile := testutil.ProfileFromAddr("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773")
 				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
-			msg:    types.NewMsgDeleteProfile("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
-			expErr: false,
+			msg:       types.NewMsgDeleteProfile("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeProfileDeleted,
@@ -251,7 +251,7 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteProfile() {
 			server := keeper.NewMsgServerImpl(suite.k)
 			_, err := server.DeleteProfile(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if tc.expErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)

--- a/x/profiles/keeper/msgs_server_profile_test.go
+++ b/x/profiles/keeper/msgs_server_profile_test.go
@@ -167,7 +167,7 @@ func (suite *KeeperTestSuite) Test_handleMsgSaveProfile() {
 				"biography",
 				"https://test.com/profile-pic",
 				"https://test.com/cover-pic",
-				suite.testData.otherUser,
+				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 			),
 			expEvents: sdk.EmptyEvents(),
 			shouldErr: true,

--- a/x/profiles/keeper/msgs_server_profile_test.go
+++ b/x/profiles/keeper/msgs_server_profile_test.go
@@ -3,6 +3,8 @@ package keeper_test
 import (
 	"time"
 
+	"github.com/desmos-labs/desmos/testutil"
+
 	"github.com/desmos-labs/desmos/x/profiles/keeper"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -10,193 +12,162 @@ import (
 	"github.com/desmos-labs/desmos/x/profiles/types"
 )
 
-func (suite *KeeperTestSuite) Test_handleMsgSaveProfile() {
-	tests := []struct {
-		name              string
-		existentProfiles  []*types.Profile
-		blockTime         time.Time
-		msg               *types.MsgSaveProfile
-		shouldErr         bool
-		expEvents         sdk.Events
-		expStoredProfiles []*types.Profile
+func (suite *KeeperTestSuite) TestMsgServer_SaveProfile() {
+	blockTime := time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC)
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		msg       *types.MsgSaveProfile
+		shouldErr bool
+		expEvents sdk.Events
+		check     func(ctx sdk.Context)
 	}{
 		{
-			name:      "Profile saved (with no previous profile created)",
-			blockTime: suite.testData.profile.CreationDate,
+			name: "profile saved (with no previous profile created)",
+			store: func(ctx sdk.Context) {
+				suite.ak.SetAccount(ctx, testutil.AccountFromAddr("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"))
+			},
 			msg: types.NewMsgSaveProfile(
 				"custom_dtag",
 				"my-nickname",
 				"my-bio",
-				"https://test.com/profile-picture",
-				"https://test.com/cover-pic",
-				suite.testData.profile.GetAddress().String(),
+				"https://tc.com/profile-picture",
+				"https://tc.com/cover-pic",
+				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
 			),
-			expStoredProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
-					"custom_dtag",
-					"my-nickname",
-					"my-bio",
-					types.NewPictures(
-						"https://test.com/profile-picture",
-						"https://test.com/cover-pic",
-					),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
+			check: func(ctx sdk.Context) {
+				_, found, err := suite.k.GetProfile(ctx, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773")
+				suite.Require().NoError(err)
+				suite.Require().True(found)
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeProfileSaved,
 					sdk.NewAttribute(types.AttributeProfileDTag, "custom_dtag"),
-					sdk.NewAttribute(types.AttributeProfileCreator, suite.testData.profile.GetAddress().String()),
-					sdk.NewAttribute(types.AttributeProfileCreationTime, suite.testData.profile.CreationDate.Format(time.RFC3339)),
+					sdk.NewAttribute(types.AttributeProfileCreator, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+					sdk.NewAttribute(types.AttributeProfileCreationTime, blockTime.Format(time.RFC3339)),
 				),
 			},
 		},
 		{
-			name:      "Profile saved (with previous profile created)",
-			blockTime: suite.testData.profile.CreationDate,
-			existentProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
+			name: "profile saved (with previous profile created)",
+			store: func(ctx sdk.Context) {
+				address := "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"
+				profile := suite.CheckProfileNoError(types.NewProfile(
 					"test_dtag",
 					"old-nickname",
 					"old-biography",
 					types.NewPictures(
-						"https://test.com/old-profile-pic",
-						"https://test.com/old-cover-pic",
+						"https://tc.com/old-profile-pic",
+						"https://tc.com/old-cover-pic",
 					),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
+					blockTime,
+					testutil.AccountFromAddr(address),
+				))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
 			msg: types.NewMsgSaveProfile(
 				"other_dtag",
 				"nickname",
 				"biography",
-				"https://test.com/profile-pic",
-				"https://test.com/cover-pic",
-				suite.testData.profile.GetAddress().String(),
+				"https://tc.com/profile-pic",
+				"https://tc.com/cover-pic",
+				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
 			),
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeProfileSaved,
 					sdk.NewAttribute(types.AttributeProfileDTag, "other_dtag"),
-					sdk.NewAttribute(types.AttributeProfileCreator, suite.testData.profile.GetAddress().String()),
-					sdk.NewAttribute(types.AttributeProfileCreationTime, suite.testData.profile.CreationDate.Format(time.RFC3339)),
+					sdk.NewAttribute(types.AttributeProfileCreator, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+					sdk.NewAttribute(types.AttributeProfileCreationTime, blockTime.Format(time.RFC3339)),
 				),
 			},
-			expStoredProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
-					"other_dtag",
-					"nickname",
-					"biography",
-					types.NewPictures(
-						"https://test.com/profile-pic",
-						"https://test.com/cover-pic",
-					),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
+			check: func(ctx sdk.Context) {
+				profile, found, err := suite.k.GetProfile(ctx, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773")
+				suite.Require().NoError(err)
+				suite.Require().True(found)
+				suite.Require().Equal("other_dtag", profile.DTag)
+				suite.Require().Equal("nickname", profile.Nickname)
 			},
 		},
 		{
-			name:      "Profile saved with same DTag but capital first letter (with previous profile created)",
-			blockTime: suite.testData.profile.CreationDate,
-			existentProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
-					"test",
+			name: "profile saved with same DTag but capital first letter (with previous profile created)",
+			store: func(ctx sdk.Context) {
+				profile := suite.CheckProfileNoError(types.NewProfile(
+					"tc",
 					"old-nickname",
 					"old-biography",
 					types.NewPictures(
-						"https://test.com/old-profile-pic",
-						"https://test.com/old-cover-pic",
+						"https://tc.com/old-profile-pic",
+						"https://tc.com/old-cover-pic",
 					),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
+					blockTime,
+					testutil.ProfileFromAddr("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+				))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
 			msg: types.NewMsgSaveProfile(
 				"Test",
 				"nickname",
 				"biography",
-				"https://test.com/profile-pic",
-				"https://test.com/cover-pic",
-				suite.testData.profile.GetAddress().String(),
+				"https://tc.com/profile-pic",
+				"https://tc.com/cover-pic",
+				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
 			),
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeProfileSaved,
 					sdk.NewAttribute(types.AttributeProfileDTag, "Test"),
-					sdk.NewAttribute(types.AttributeProfileCreator, suite.testData.profile.GetAddress().String()),
-					sdk.NewAttribute(types.AttributeProfileCreationTime, suite.testData.profile.CreationDate.Format(time.RFC3339)),
+					sdk.NewAttribute(types.AttributeProfileCreator, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+					sdk.NewAttribute(types.AttributeProfileCreationTime, blockTime.Format(time.RFC3339)),
 				),
 			},
-			expStoredProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
-					"Test",
-					"nickname",
-					"biography",
-					types.NewPictures(
-						"https://test.com/profile-pic",
-						"https://test.com/cover-pic",
-					),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
+			check: func(ctx sdk.Context) {
+				profile, found, err := suite.k.GetProfile(ctx, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773")
+				suite.Require().NoError(err)
+				suite.Require().True(found)
+				suite.Require().Equal("Test", profile.DTag)
+				suite.Require().Equal("nickname", profile.Nickname)
 			},
 		},
 		{
-			name:      "Profile not saved because of the same DTag",
-			blockTime: suite.testData.profile.CreationDate,
-			existentProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
-					"test",
+			name: "profile not saved because of the same DTag",
+			store: func(ctx sdk.Context) {
+				profile := suite.CheckProfileNoError(types.NewProfile(
+					"tc",
 					"nickname",
 					"biography",
 					types.NewPictures(
-						"https://test.com/profile-pic",
-						"https://test.com/cover-pic",
+						"https://tc.com/profile-pic",
+						"https://tc.com/cover-pic",
 					),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
+					blockTime,
+					testutil.AccountFromAddr("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+				))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
 			msg: types.NewMsgSaveProfile(
 				"Test",
 				"another-one",
 				"biography",
-				"https://test.com/profile-pic",
-				"https://test.com/cover-pic",
+				"https://tc.com/profile-pic",
+				"https://tc.com/cover-pic",
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 			),
-			expEvents: sdk.EmptyEvents(),
 			shouldErr: true,
-			expStoredProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
-					"test",
-					"nickname",
-					"biography",
-					types.NewPictures(
-						"https://test.com/profile-pic",
-						"https://test.com/cover-pic",
-					),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
-			},
 		},
 		{
-			name:      "Profile not edited because of the invalid profile picture",
-			blockTime: suite.testData.profile.CreationDate,
-			existentProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
+			name: "profile not edited because of the invalid profile picture",
+			store: func(ctx sdk.Context) {
+				profile := suite.CheckProfileNoError(types.NewProfile(
 					"custom_dtag",
 					"biography",
 					"",
 					types.NewPictures("", ""),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
+					blockTime,
+					testutil.AccountFromAddr("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+				))
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
 			msg: types.NewMsgSaveProfile(
 				"custom_dtag",
@@ -204,103 +175,87 @@ func (suite *KeeperTestSuite) Test_handleMsgSaveProfile() {
 				"",
 				"invalid-pic",
 				"",
-				suite.testData.profile.GetAddress().String(),
+				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
 			),
-			expEvents: sdk.EmptyEvents(),
 			shouldErr: true,
-			expStoredProfiles: []*types.Profile{
-				suite.CheckProfileNoError(types.NewProfile(
-					"custom_dtag",
-					"biography",
-					"",
-					types.NewPictures("", ""),
-					suite.testData.profile.CreationDate,
-					suite.testData.profile.GetAccount(),
-				)),
-			},
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		suite.Run(test.name, func() {
-			suite.SetupTest()
-			suite.k.SetParams(suite.ctx, types.DefaultParams())
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			ctx = ctx.WithBlockTime(blockTime)
 
-			suite.ctx = suite.ctx.WithBlockTime(test.blockTime)
-			for _, acc := range test.existentProfiles {
-				err := suite.k.StoreProfile(suite.ctx, acc)
-				suite.Require().NoError(err)
+			suite.k.SetParams(ctx, types.DefaultParams())
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
 			server := keeper.NewMsgServerImpl(suite.k)
-			_, err := server.SaveProfile(sdk.WrapSDKContext(suite.ctx), test.msg)
+			_, err := server.SaveProfile(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if test.shouldErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
-			}
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 
-			stored := suite.k.GetProfiles(suite.ctx)
-			suite.Require().Len(stored, len(test.expStoredProfiles))
-			for _, profile := range stored {
-				suite.Require().Contains(test.expStoredProfiles, profile)
+				if tc.check != nil {
+					tc.check(ctx)
+				}
 			}
 		})
 	}
 }
 
-func (suite *KeeperTestSuite) Test_handleMsgDeleteProfile() {
-	tests := []struct {
-		name           string
-		storedProfiles []*types.Profile
-		msg            *types.MsgDeleteProfile
-		expErr         bool
-		expEvents      sdk.Events
+func (suite *KeeperTestSuite) TestMsgServer_DeleteProfile() {
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		msg       *types.MsgDeleteProfile
+		expErr    bool
+		expEvents sdk.Events
 	}{
 		{
-			name:           "Profile doesn't exists",
-			storedProfiles: nil,
-			msg:            types.NewMsgDeleteProfile(suite.testData.profile.GetAddress().String()),
-			expErr:         true,
-			expEvents:      sdk.EmptyEvents(),
+			name:      "non existent profile returns error",
+			msg:       types.NewMsgDeleteProfile("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
+			expErr:    true,
+			expEvents: sdk.EmptyEvents(),
 		},
 		{
-			name: "Profile deleted successfully",
-			storedProfiles: []*types.Profile{
-				suite.testData.profile.Profile,
+			name: "existent profile is deleted successfully",
+			store: func(ctx sdk.Context) {
+				profile := testutil.ProfileFromAddr("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773")
+				suite.Require().NoError(suite.k.StoreProfile(ctx, profile))
 			},
-			msg:    types.NewMsgDeleteProfile(suite.testData.profile.GetAddress().String()),
+			msg:    types.NewMsgDeleteProfile("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
 			expErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					types.EventTypeProfileDeleted,
-					sdk.NewAttribute(types.AttributeProfileCreator, suite.testData.profile.GetAddress().String()),
+					sdk.NewAttribute(types.AttributeProfileCreator, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
 				),
 			},
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		suite.Run(test.name, func() {
-			suite.SetupTest()
-
-			for _, profile := range test.storedProfiles {
-				err := suite.k.StoreProfile(suite.ctx, profile)
-				suite.Require().NoError(err)
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			ctx, _ := suite.ctx.CacheContext()
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
 			server := keeper.NewMsgServerImpl(suite.k)
-			_, err := server.DeleteProfile(sdk.WrapSDKContext(suite.ctx), test.msg)
+			_, err := server.DeleteProfile(sdk.WrapSDKContext(ctx), tc.msg)
 
-			if test.expErr {
+			if tc.expErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(test.expEvents, suite.ctx.EventManager().Events())
+				suite.Require().Equal(tc.expEvents, ctx.EventManager().Events())
 			}
 		})
 	}

--- a/x/profiles/keeper/relay_app_links_test.go
+++ b/x/profiles/keeper/relay_app_links_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/desmos-labs/desmos/testutil"
+
 	"github.com/desmos-labs/desmos/pkg/obi"
 
 	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types"
@@ -133,7 +135,7 @@ func (suite *KeeperTestSuite) TestKeeper_StartProfileConnection() {
 				callData = "call_data"
 			},
 			storeChainA: func(ctx sdk.Context) {
-				profile := suite.CreateProfileFromAddress(suite.chainA.Account.GetAddress().String())
+				profile := testutil.ProfileFromAddr(suite.chainA.Account.GetAddress().String())
 				suite.chainA.App.AccountKeeper.SetAccount(ctx, profile)
 			},
 			expPass: true,
@@ -143,7 +145,7 @@ func (suite *KeeperTestSuite) TestKeeper_StartProfileConnection() {
 	for _, tc := range testCases {
 		tc := tc
 		suite.Run(tc.name, func() {
-			suite.SetupTest()
+			suite.SetupIBCTest()
 
 			tc.malleate()
 			if tc.storeChainA != nil {
@@ -173,8 +175,8 @@ func (suite *KeeperTestSuite) TestKeeper_StartProfileConnection() {
 
 func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 	profile := suite.GetRandomProfile()
-	value := "twitter-account"
-	hexSig := hex.EncodeToString(profile.Sign([]byte("twitter-account")))
+	value := "twitter-profile"
+	hexSig := hex.EncodeToString(profile.Sign([]byte("twitter-profile")))
 
 	type resultData struct {
 		Signature string `obi:"signature"`
@@ -187,7 +189,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 	suite.Require().NoError(err)
 	resultBase64 := base64.StdEncoding.EncodeToString(result)
 
-	useCases := []struct {
+	testCases := []struct {
 		name      string
 		store     func(sdk.Context)
 		data      oracletypes.OracleResponsePacketData
@@ -195,7 +197,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 		expLink   types.ApplicationLink
 	}{
 		{
-			name: "Non existing connection returns error",
+			name: "non existing connection returns error",
 			data: createResponsePacketData(
 				"client_id",
 				-1,
@@ -205,9 +207,9 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 			shouldErr: true,
 		},
 		{
-			name: "Resolve status expired updates connection properly",
+			name: "resolve status expired updates connection properly",
 			store: func(ctx sdk.Context) {
-				profile := suite.CreateProfileFromAddress("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
+				profile := testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
 				suite.ak.SetAccount(ctx, profile)
 
 				link := types.NewApplicationLink(
@@ -248,9 +250,9 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 			),
 		},
 		{
-			name: "Resolve status failure updates connection properly",
+			name: "resolve status failure updates connection properly",
 			store: func(ctx sdk.Context) {
-				profile := suite.CreateProfileFromAddress("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
+				profile := testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
 				suite.ak.SetAccount(ctx, profile)
 
 				link := types.NewApplicationLink(
@@ -291,9 +293,9 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 			),
 		},
 		{
-			name: "Wrongly encoded result returns error",
+			name: "wrongly encoded result returns error",
 			store: func(ctx sdk.Context) {
-				profile := suite.CreateProfileFromAddress("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
+				profile := testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
 				suite.ak.SetAccount(ctx, profile)
 
 				link := types.NewApplicationLink(
@@ -321,9 +323,9 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 			shouldErr: true,
 		},
 		{
-			name: "Different returned value (username) updates correctly",
+			name: "different returned value (username) updates correctly",
 			store: func(ctx sdk.Context) {
-				profile := suite.CreateProfileFromAddress("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
+				profile := testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
 				suite.ak.SetAccount(ctx, profile)
 
 				link := types.NewApplicationLink(
@@ -364,9 +366,9 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 			),
 		},
 		{
-			name: "Wrongly encoded result signature error",
+			name: "wrongly encoded result signature error",
 			store: func(ctx sdk.Context) {
-				profile := suite.CreateProfileFromAddress("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
+				profile := testutil.ProfileFromAddr("cosmos19xz3mrvzvp9ymgmudhpukucg6668l5haakh04x")
 				suite.ak.SetAccount(ctx, profile)
 
 				link := types.NewApplicationLink(
@@ -394,7 +396,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 			shouldErr: true,
 		},
 		{
-			name: "Wrong signature updates connection properly",
+			name: "wrong signature updates connection properly",
 			store: func(ctx sdk.Context) {
 				suite.ak.SetAccount(ctx, profile.Profile)
 
@@ -436,7 +438,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 			),
 		},
 		{
-			name: "Valid resolve status success updates connection properly",
+			name: "valid resolve status success updates connection properly",
 			store: func(ctx sdk.Context) {
 				suite.ak.SetAccount(ctx, profile.Profile)
 
@@ -474,24 +476,24 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 		},
 	}
 
-	for _, uc := range useCases {
-		uc := uc
-		suite.Run(uc.name, func() {
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
-			if uc.store != nil {
-				uc.store(ctx)
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err := suite.k.OnRecvApplicationLinkPacketData(ctx, uc.data)
+			err = suite.k.OnRecvApplicationLinkPacketData(ctx, tc.data)
 
-			if uc.shouldErr {
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 
-				stored, err := suite.k.GetApplicationLinkByClientID(ctx, uc.expLink.OracleRequest.ClientID)
+				stored, err := suite.k.GetApplicationLinkByClientID(ctx, tc.expLink.OracleRequest.ClientID)
 				suite.Require().NoError(err)
-				suite.Require().Truef(uc.expLink.Equal(stored), "%s\n%s", uc.expLink, stored)
+				suite.Require().Truef(tc.expLink.Equal(stored), "%s\n%s", tc.expLink, stored)
 			}
 		})
 	}
@@ -500,7 +502,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnRecvApplicationLinkPacketData() {
 func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestAcknowledgementPacket() {
 	result := oracletypes.OracleRequestPacketAcknowledgement{RequestID: 1000}
 
-	usecases := []struct {
+	testCases := []struct {
 		name      string
 		store     func(ctx sdk.Context)
 		data      oracletypes.OracleRequestPacketData
@@ -532,7 +534,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestAcknowledgementPacket() 
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.ak.SetAccount(ctx, testutil.ProfileFromAddr(address))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -571,7 +573,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestAcknowledgementPacket() 
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.ak.SetAccount(ctx, testutil.ProfileFromAddr(address))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -597,7 +599,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestAcknowledgementPacket() 
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.ak.SetAccount(ctx, testutil.ProfileFromAddr(address))
 				err := suite.k.SaveApplicationLink(ctx, link)
 				suite.Require().NoError(err)
 			},
@@ -620,35 +622,35 @@ func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestAcknowledgementPacket() 
 		},
 	}
 
-	for _, uc := range usecases {
-		uc := uc
-		suite.Run(uc.name, func() {
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
-			if uc.store != nil {
-				uc.store(ctx)
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err := suite.k.OnOracleRequestAcknowledgementPacket(ctx, uc.data, uc.ack)
-			if uc.shouldErr {
+			err := suite.k.OnOracleRequestAcknowledgementPacket(ctx, tc.data, tc.ack)
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 
-				link, err := suite.k.GetApplicationLinkByClientID(ctx, uc.data.ClientID)
+				link, err := suite.k.GetApplicationLinkByClientID(ctx, tc.data.ClientID)
 				suite.Require().NoError(err)
-				suite.Require().Equal(uc.expLink, link)
+				suite.Require().Equal(tc.expLink, link)
 			}
 		})
 	}
 }
 
 func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestTimeoutPacket() {
-	usecases := []struct {
+	testCases := []struct {
 		name      string
 		store     func(ctx sdk.Context)
 		data      oracletypes.OracleRequestPacketData
 		shouldErr bool
-		verify    func(ctx sdk.Context)
+		check     func(ctx sdk.Context)
 	}{
 		{
 			name:      "invalid client id request returns error",
@@ -673,12 +675,12 @@ func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestTimeoutPacket() {
 					time.Date(2020, 1, 1, 00, 00, 00, 000, time.UTC),
 				)
 
-				suite.ak.SetAccount(ctx, suite.CreateProfileFromAddress(address))
+				suite.ak.SetAccount(ctx, testutil.ProfileFromAddr(address))
 				suite.Require().NoError(suite.k.SaveApplicationLink(ctx, link))
 			},
 			data:      createRequestPacketData("client_id"),
 			shouldErr: false,
-			verify: func(ctx sdk.Context) {
+			check: func(ctx sdk.Context) {
 				link, err := suite.k.GetApplicationLinkByClientID(ctx, "client_id")
 				suite.Require().NoError(err)
 
@@ -700,23 +702,23 @@ func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestTimeoutPacket() {
 		},
 	}
 
-	for _, uc := range usecases {
-		uc := uc
-		suite.Run(uc.name, func() {
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
 			ctx, _ := suite.ctx.CacheContext()
-			if uc.store != nil {
-				uc.store(ctx)
+			if tc.store != nil {
+				tc.store(ctx)
 			}
 
-			err := suite.k.OnOracleRequestTimeoutPacket(ctx, uc.data)
-			if uc.shouldErr {
+			err := suite.k.OnOracleRequestTimeoutPacket(ctx, tc.data)
+			if tc.shouldErr {
 				suite.Require().Error(err)
 			} else {
 				suite.Require().NoError(err)
 			}
 
-			if uc.verify != nil {
-				uc.verify(ctx)
+			if tc.check != nil {
+				tc.check(ctx)
 			}
 		})
 	}

--- a/x/profiles/keeper/relay_chain_links.go
+++ b/x/profiles/keeper/relay_chain_links.go
@@ -48,7 +48,7 @@ func (k Keeper) OnRecvLinkChainAccountPacket(
 	// Make sure the profile public key and the one provided are equals
 	if !bytes.Equal(pubKey.Bytes(), profile.GetPubKey().Bytes()) {
 		return packetAck, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest,
-			"invalid pub key value: expected %s but got %s instead",
+			"invalid pub key value: expRelationships %s but got %s instead",
 			hex.EncodeToString(profile.GetPubKey().Bytes()), hex.EncodeToString(pubKey.Bytes()))
 	}
 

--- a/x/profiles/keeper/relay_chain_links.go
+++ b/x/profiles/keeper/relay_chain_links.go
@@ -48,7 +48,7 @@ func (k Keeper) OnRecvLinkChainAccountPacket(
 	// Make sure the profile public key and the one provided are equals
 	if !bytes.Equal(pubKey.Bytes(), profile.GetPubKey().Bytes()) {
 		return packetAck, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest,
-			"invalid pub key value: expRelationships %s but got %s instead",
+			"invalid pub key value: expected %s but got %s instead",
 			hex.EncodeToString(profile.GetPubKey().Bytes()), hex.EncodeToString(pubKey.Bytes()))
 	}
 

--- a/x/profiles/keeper/relay_chain_links_test.go
+++ b/x/profiles/keeper/relay_chain_links_test.go
@@ -25,7 +25,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 		expPass     bool
 	}{
 		{
-			name: "Invalid packet returns error",
+			name: "invalid packet returns error",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				packetData = types.LinkChainAccountPacketData{
 					SourceAddress: nil,
@@ -34,9 +34,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 						srcSigHex,
 						srcAddr,
 					),
-					SourceChainConfig: types.NewChainConfig(
-						"cosmos",
-					),
+					SourceChainConfig:  types.NewChainConfig("cosmos"),
 					DestinationAddress: destAddr,
 					DestinationProof: types.NewProof(
 						suite.chainB.Account.GetPubKey(),
@@ -48,7 +46,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			expPass: false,
 		},
 		{
-			name: "Unpack source address failed returns error",
+			name: "failed unpack source address returns error",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				invalidAny, err := codectypes.NewAnyWithValue(secp256k1.GenPrivKey())
 				suite.Require().NoError(err)
@@ -59,9 +57,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 						srcSigHex,
 						srcAddr,
 					),
-					SourceChainConfig: types.NewChainConfig(
-						"cosmos",
-					),
+					SourceChainConfig:  types.NewChainConfig("cosmos"),
 					DestinationAddress: destAddr,
 					DestinationProof: types.NewProof(
 						suite.chainB.Account.GetPubKey(),
@@ -73,7 +69,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			expPass: false,
 		},
 		{
-			name: "Invalid destination address returns error",
+			name: "invalid destination address returns error",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				packetData = types.NewLinkChainAccountPacketData(
 					types.NewBech32Address(srcAddr, "cosmos"),
@@ -82,9 +78,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 						srcSigHex,
 						srcAddr,
 					),
-					types.NewChainConfig(
-						"cosmos",
-					),
+					types.NewChainConfig("cosmos"),
 					"cosmos1asdjlansdjhasd",
 					types.NewProof(
 						suite.chainB.Account.GetPubKey(),
@@ -96,7 +90,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			expPass: false,
 		},
 		{
-			name: "Destination address without profile returns error",
+			name: "destination address without profile returns error",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				packetData = types.NewLinkChainAccountPacketData(
 					types.NewBech32Address(srcAddr, "cosmos"),
@@ -105,9 +99,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 						srcSigHex,
 						srcAddr,
 					),
-					types.NewChainConfig(
-						"cosmos",
-					),
+					types.NewChainConfig("cosmos"),
 					destAddr,
 					types.NewProof(
 						suite.chainB.Account.GetPubKey(),
@@ -119,7 +111,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			expPass: false,
 		},
 		{
-			name: "Profile public key does not equal to provided public key returns error",
+			name: "returns error if the profile public key does not equal to provided public key",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				packetData = types.NewLinkChainAccountPacketData(
 					types.NewBech32Address(srcAddr, "cosmos"),
@@ -128,9 +120,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 						srcSigHex,
 						srcAddr,
 					),
-					types.NewChainConfig(
-						"cosmos",
-					),
+					types.NewChainConfig("cosmos"),
 					destAddr,
 					types.NewProof(
 						suite.chainB.Account.GetPubKey(),
@@ -162,7 +152,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			expPass: false,
 		},
 		{
-			name: "Verify destination proof failed returns error",
+			name: "returns error when destination proof verification fails",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				packetData = types.NewLinkChainAccountPacketData(
 					types.NewBech32Address(srcAddr, "cosmos"),
@@ -205,7 +195,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			expPass: false,
 		},
 		{
-			name: "Failed to store chain link returns error",
+			name: "returns error when failed to store chain link",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				packetData = types.NewLinkChainAccountPacketData(
 					types.NewBech32Address(srcAddr, "cosmos"),
@@ -260,7 +250,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			expPass: false,
 		},
 		{
-			name: "Create link from source chain successfully",
+			name: "valid link is created successfully",
 			malleate: func(srcAddr, srcSigHex, destAddr, destSigHex string) {
 				packetData = types.NewLinkChainAccountPacketData(
 					types.NewBech32Address(srcAddr, "cosmos"),

--- a/x/profiles/keeper/relay_chain_links_test.go
+++ b/x/profiles/keeper/relay_chain_links_test.go
@@ -17,7 +17,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 		srcAddr    string
 	)
 
-	tests := []struct {
+	testCases := []struct {
 		name        string
 		malleate    func(srcAddr, srcSigHex, destAddr, destSigHex string)
 		store       func()
@@ -136,7 +136,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 
 				profile, err := types.NewProfile(
 					"dtag",
-					"test-user",
+					"tc-user",
 					"biography",
 					types.NewPictures(
 						"https://shorturl.at/adnX3",
@@ -179,7 +179,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 
 				profile, err := types.NewProfile(
 					"dtag",
-					"test-user",
+					"tc-user",
 					"biography",
 					types.NewPictures(
 						"https://shorturl.at/adnX3",
@@ -222,7 +222,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 
 				profile, err := types.NewProfile(
 					"dtag",
-					"test-user",
+					"tc-user",
 					"biography",
 					types.NewPictures(
 						"https://shorturl.at/adnX3",
@@ -277,7 +277,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 
 				profile, err := types.NewProfile(
 					"dtag",
-					"test-user",
+					"tc-user",
 					"biography",
 					types.NewPictures(
 						"https://shorturl.at/adnX3",
@@ -294,10 +294,10 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		suite.Run(test.name, func() {
-			suite.initIBCConnection()
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			suite.SetupIBCTest()
 			srcAddr = suite.chainA.Account.GetAddress().String()
 
 			srcSig, err := suite.chainA.PrivKey.Sign([]byte(srcAddr))
@@ -309,13 +309,13 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			suite.NoError(err)
 			destSigHex := hex.EncodeToString(dstSig)
 
-			test.malleate(srcAddr, srcSigHex, destAddr, destSigHex)
-			if test.store != nil {
-				test.store()
+			tc.malleate(srcAddr, srcSigHex, destAddr, destSigHex)
+			if tc.store != nil {
+				tc.store()
 			}
 
 			_, err = suite.chainB.App.ProfileKeeper.OnRecvLinkChainAccountPacket(suite.chainB.GetContext(), packetData)
-			if test.expPass {
+			if tc.expPass {
 				suite.Require().NoError(err)
 			} else {
 				suite.Require().Error(err)

--- a/x/profiles/types/account_test.go
+++ b/x/profiles/types/account_test.go
@@ -309,7 +309,7 @@ func TestProfile_Validate(t *testing.T) {
 	}
 }
 
-func TestProfile_Serialization(t *testing.T) {
+func TestProfileSerialization(t *testing.T) {
 
 	cdc := app.MakeTestEncodingConfig().Marshaler
 

--- a/x/profiles/types/models_app_links_test.go
+++ b/x/profiles/types/models_app_links_test.go
@@ -388,12 +388,12 @@ func TestResult_Failed__Validate(t *testing.T) {
 		shouldErr bool
 	}{
 		{
-			name:      "invalid error string returns error",
+			name:      "invalid error returns error",
 			result:    types.NewErrorResult(" "),
 			shouldErr: true,
 		},
 		{
-			name:      "valid error string returns no error",
+			name:      "valid error returns no error",
 			result:    types.NewErrorResult("error"),
 			shouldErr: false,
 		},

--- a/x/profiles/types/models_params_test.go
+++ b/x/profiles/types/models_params_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/desmos-labs/desmos/x/profiles/types"
 )
 
-func TestParams_Validate(t *testing.T) {
+func TestValidateParams(t *testing.T) {
 	testCases := []struct {
 		name      string
 		params    types.Params


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR improves the keeper tests for the `x/profiles` module. References #481 

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [ ] Wrote integration tests (simulation & CLI). 
- [ ] Updated the documentation. 
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
