### PR TITLE
fix: allow AddressData to be properly serialized using Amino

### DIFF
--- a/.changeset/entries/fc6dda08613b49d8b7c870c929fc0f026474816d08093146bc8ac6ddf6257f45.yaml
+++ b/.changeset/entries/fc6dda08613b49d8b7c870c929fc0f026474816d08093146bc8ac6ddf6257f45.yaml
@@ -1,0 +1,7 @@
+type: fix
+module: x/profiles
+pull_request: 680
+description: Fixed the wrong serialization of tha AddressData interface when using
+  amino
+backward_compatible: true
+date: 2021-11-24T10:48:29.580407601Z

--- a/x/profiles/types/codec.go
+++ b/x/profiles/types/codec.go
@@ -25,6 +25,10 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(MsgLinkApplication{}, "desmos/MsgLinkApplication", nil)
 	cdc.RegisterConcrete(MsgUnlinkApplication{}, "desmos/MsgUnlinkApplication", nil)
 
+	cdc.RegisterInterface((*AddressData)(nil), nil)
+	cdc.RegisterConcrete(&Bech32Address{}, "desmos/Bech32Address", nil)
+	cdc.RegisterConcrete(&Base58Address{}, "desmos/Base58Address", nil)
+
 	cdc.RegisterConcrete(&Profile{}, "desmos/Profile", nil)
 }
 

--- a/x/profiles/types/msgs_chain_links_test.go
+++ b/x/profiles/types/msgs_chain_links_test.go
@@ -99,7 +99,7 @@ func TestMsgLinkChainAccount_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgLinkChainAccount_GetSignBytes(t *testing.T) {
-	expected := `{"type":"desmos/MsgLinkChainAccount","value":{"chain_address":{"prefix":"cosmos","value":"cosmos1xmquc944hzu6n6qtljcexkuhhz76mucxtgm5x0"},"chain_config":{"name":"cosmos"},"proof":{"plain_text":"74657874","pub_key":{"type":"tendermint/PubKeySecp256k1","value":"A+RxOqvS0RYdF/NU3xSolfmfZc7YUKu4fvJLbnCCQBY3"},"signature":"ad112abb30e5240c7b9d21b4cc5421d76cfadfcd5977cca262523b5f5bc759457d4aa6d5c1eb6223db104b47aa1f222468be8eb5bb2762b971622ac5b96351b5"},"signer":"cosmos1u9hgsqfpe3snftr7p7fsyja3wtlmj2sgf2w9yl"}}`
+	expected := `{"type":"desmos/MsgLinkChainAccount","value":{"chain_address":{"type":"desmos/Bech32Address","value":{"prefix":"cosmos","value":"cosmos1xmquc944hzu6n6qtljcexkuhhz76mucxtgm5x0"}},"chain_config":{"name":"cosmos"},"proof":{"plain_text":"74657874","pub_key":{"type":"tendermint/PubKeySecp256k1","value":"A+RxOqvS0RYdF/NU3xSolfmfZc7YUKu4fvJLbnCCQBY3"},"signature":"ad112abb30e5240c7b9d21b4cc5421d76cfadfcd5977cca262523b5f5bc759457d4aa6d5c1eb6223db104b47aa1f222468be8eb5bb2762b971622ac5b96351b5"},"signer":"cosmos1u9hgsqfpe3snftr7p7fsyja3wtlmj2sgf2w9yl"}}`
 	require.Equal(t, expected, string(msgChainLinkAccount.GetSignBytes()))
 }
 


### PR DESCRIPTION
## Description
This PR fixes a bug that currently makes it impossible to properly serialize an `AddressData` value using Amino. 

Currently the `AddressData` interface has two implementations that are serialized as follows when using Amino: 

- `Base32Address`
   ```json
   {
     "prefix": "",
     "value": ""
   }
   ```
- `Bech58Address`
   ```json
   {
     "value": ""
   }
   ```
However, since it is an interface, it should have been registered properly and should be serialized as follow: 
- `Base32Address`
   ```json
   {
     "type": "desmos/Bech32Address",
     "value": {
       "prefix": "",
       "value": ""
     }
   }
   ```
- `Base58Address`
   ```json
   {
     "type": "desmos/Base58Address",
     "value": {
       "value": ""
     }
   }
   ```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)