### PR TITLE
ci: fixing coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,12 +186,15 @@ jobs:
 
       - name: Filter out DONTCOVER 🔍
         run: |
+          module = $(cat go.mod | grep module) 
+          module = $(echo $module | sed 's/module //g')
+          
           excludelist="$(find ./ -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
           excludelist+=" $(find ./ -type f -name '*.pb.go')"
           excludelist+=" $(find ./ -type f -name '*.pb.gw.go')"
           excludelist+=" $(find ./ -type f -path './tests/mocks/*.go')"
           for filename in ${excludelist}; do
-            filename=$(echo $filename | sed 's/^./github.com\/desmos-labs\/desmos/g')
+            filename=$(echo $filename | sed "s/^./$module/g")
             echo "Excluding ${filename} from coverage report..."
             sed -i.bak "/$(echo $filename | sed 's/\//\\\//g')/d" coverage.txt
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,8 +186,8 @@ jobs:
 
       - name: Filter out DONTCOVER 🔍
         run: |
-          module="$(cat go.mod | grep module)" 
-          module="$(echo $module | sed 's/module //g')"
+          module=$(cat go.mod | grep module) 
+          module=$(echo $module | sed 's/module //g')
           
           excludelist="$(find ./ -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
           excludelist+=" $(find ./ -type f -name '*.pb.go')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,7 +194,7 @@ jobs:
           excludelist+=" $(find ./ -type f -name '*.pb.gw.go')"
           excludelist+=" $(find ./ -type f -path './tests/mocks/*.go')"
           for filename in ${excludelist}; do
-            filename=$(echo $filename | sed -i "s|^.|$module|g")
+            filename=$(echo $filename | sed "s|^.|$module|g")
             echo "Excluding ${filename} from coverage report..."
             sed -i.bak "/$(echo $filename | sed 's/\//\\\//g')/d" coverage.txt
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,14 +187,14 @@ jobs:
       - name: Filter out DONTCOVER 🔍
         run: |
           module=$(cat go.mod | grep module) 
-          module=$(echo $module | sed 's/module //g')
+          module=$(echo $module | sed "s/module //g")
           
           excludelist="$(find ./ -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
           excludelist+=" $(find ./ -type f -name '*.pb.go')"
           excludelist+=" $(find ./ -type f -name '*.pb.gw.go')"
           excludelist+=" $(find ./ -type f -path './tests/mocks/*.go')"
           for filename in ${excludelist}; do
-            filename=$(echo $filename | sed "s/^./$module/g")
+            filename=$(echo $filename | sed -i "s|^.|$module|g")
             echo "Excluding ${filename} from coverage report..."
             sed -i.bak "/$(echo $filename | sed 's/\//\\\//g')/d" coverage.txt
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,8 +186,8 @@ jobs:
 
       - name: Filter out DONTCOVER 🔍
         run: |
-          module = $(cat go.mod | grep module) 
-          module = $(echo $module | sed 's/module //g')
+          module="$(cat go.mod | grep module)" 
+          module="$(echo $module | sed 's/module //g')"
           
           excludelist="$(find ./ -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
           excludelist+=" $(find ./ -type f -name '*.pb.go')"

--- a/x/profiles/module.go
+++ b/x/profiles/module.go
@@ -90,7 +90,7 @@ func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) 
 	types.RegisterInterfaces(registry)
 }
 
-//____________________________________________________________________________
+// --------------------------------------------------------------------------------------------------------------------
 
 // AppModule implements an application module for the profiles module.
 type AppModule struct {


### PR DESCRIPTION
## Description

Starting with Desmos `v2`, due to the `go.mod` module change (from `github.com/desmos-labs/desmos` to `github.com/desmos-labs/desmos/v2`) the entire coverage has drastically decreased. This was due to the fact that Codecov couldn't find anymore the module `github.com/desmos-labs/desmos` and all the files in the new module were not tracked. 

To fix this, I have now revisited the Github workflow that computes the coverage, by editing how the final `coverage.txt` is generated. From now, even if we change the module name inside the `go.mod` file we should see the coverage always correct.

**NOTE**: The `.go` file change is only there to trigger the CI that computes the coverage and to see whether it's fixed or not 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)