### PR TITLE
fix: wrong message values usage during subspace creation

### DIFF
--- a/x/subspaces/keeper/msg_server.go
+++ b/x/subspaces/keeper/msg_server.go
@@ -34,7 +34,7 @@ func (k msgServer) CreateSubspace(goCtx context.Context, msg *types.MsgCreateSub
 	}
 
 	// Create and validate the subspace
-	subspace := types.NewSubspace(subspaceID, msg.Name, msg.Description, msg.Owner, msg.Creator, msg.Treasury, ctx.BlockTime())
+	subspace := types.NewSubspace(subspaceID, msg.Name, msg.Description, msg.Treasury, msg.Owner, msg.Creator, ctx.BlockTime())
 	if err := subspace.Validate(); err != nil {
 		return nil, err
 	}

--- a/x/subspaces/keeper/msg_server_test.go
+++ b/x/subspaces/keeper/msg_server_test.go
@@ -96,6 +96,55 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateSubspace() {
 			},
 		},
 		{
+			name: "subspace is created with three different addresses properly",
+			store: func(ctx sdk.Context) {
+				store := ctx.KVStore(suite.storeKey)
+				store.Set(types.SubspaceIDKey, types.GetSubspaceIDBytes(1))
+			},
+			msg: types.NewMsgCreateSubspace(
+				"Test subspace",
+				"This is a test subspace",
+				"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+				"cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t",
+				"cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0",
+			),
+			shouldErr:   false,
+			expResponse: &types.MsgCreateSubspaceResponse{SubspaceID: 1},
+			expEvents: sdk.Events{
+				sdk.NewEvent(
+					sdk.EventTypeMessage,
+					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
+				),
+				sdk.NewEvent(
+					types.EventTypeCreateSubspace,
+					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
+					sdk.NewAttribute(types.AttributeKeySubspaceName, "Test subspace"),
+					sdk.NewAttribute(types.AttributeKeySubspaceCreator, "cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
+					sdk.NewAttribute(types.AttributeKeyCreationTime, "2020-01-01T12:00:00Z"),
+				),
+			},
+			check: func(ctx sdk.Context) {
+				// Make sure the subspace is stored
+				subspace, found := suite.k.GetSubspace(ctx, 1)
+				suite.Require().True(found)
+				suite.Require().Equal(types.NewSubspace(
+					1,
+					"Test subspace",
+					"This is a test subspace",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					"cosmos17qcf9sv5yk0ly5vt3ztev70nwf6c5sprkwfh8t",
+					"cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0",
+					time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
+				), subspace)
+
+				// Make sure the subspace id has increased
+				store := ctx.KVStore(suite.storeKey)
+				id := types.GetSubspaceIDFromBytes(store.Get(types.SubspaceIDKey))
+				suite.Require().Equal(uint64(2), id)
+			},
+		},
+		{
 			name: "subspace has correct id when another subspace already exists",
 			store: func(ctx sdk.Context) {
 				store := ctx.KVStore(suite.storeKey)

--- a/x/subspaces/keeper/msg_server_test.go
+++ b/x/subspaces/keeper/msg_server_test.go
@@ -96,7 +96,7 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateSubspace() {
 			},
 		},
 		{
-			name: "subspace is created with three different addresses properly",
+			name: "subspace with three different addresses is created properly",
 			store: func(ctx sdk.Context) {
 				store := ctx.KVStore(suite.storeKey)
 				store.Set(types.SubspaceIDKey, types.GetSubspaceIDBytes(1))


### PR DESCRIPTION
## Description

Closes: #746 

This PR fixes the parameter order bug of the subspace creation in the msg server.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)