### PR TITLE
feat: added missing query user permissions cmd

### DIFF
--- a/x/subspaces/client/cli/cli_test.go
+++ b/x/subspaces/client/cli/cli_test.go
@@ -332,6 +332,60 @@ func (s *IntegrationTestSuite) TestCmdQueryUserGroupMembers() {
 	}
 }
 
+func (s *IntegrationTestSuite) TestCmdQueryUserPermissions() {
+	val := s.network.Validators[0]
+	testCases := []struct {
+		name        string
+		args        []string
+		shouldErr   bool
+		expResponse types.QueryUserPermissionsResponse
+	}{
+		{
+			name: "subspace not found returns error",
+			args: []string{
+				"11", "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53",
+				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+			},
+			shouldErr: true,
+		},
+		{
+			name: "user permissions are returned correctly",
+			args: []string{
+				"2", "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53",
+				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+			},
+			shouldErr: false,
+			expResponse: types.QueryUserPermissionsResponse{
+				Permissions: types.PermissionManageGroups,
+				Details: []types.PermissionDetail{
+					types.NewPermissionDetailGroup(1, types.PermissionManageGroups),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		s.Run(tc.name, func() {
+			cmd := cli.GetCmdQueryUserPermissions()
+			clientCtx := val.ClientCtx
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
+
+			if tc.shouldErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+
+				var response types.QueryUserPermissionsResponse
+				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
+				s.Require().Equal(tc.expResponse.Permissions, response.Permissions)
+				s.Require().Equal(tc.expResponse.Details, response.Details)
+			}
+		})
+	}
+}
+
 func (s *IntegrationTestSuite) TestCmdCreateSubspace() {
 	val := s.network.Validators[0]
 	testCases := []struct {

--- a/x/subspaces/client/cli/query.go
+++ b/x/subspaces/client/cli/query.go
@@ -28,6 +28,7 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdQuerySubspaces(),
 
 		GetGroupsQueryCmd(),
+		GetCmdQueryUserPermissions(),
 	)
 	return subspaceQueryCmd
 }
@@ -124,7 +125,7 @@ func GetGroupsQueryCmd() *cobra.Command {
 func GetCmdQueryUserGroups() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list [subspace-id]",
-		Short: "Query subspaces with optional pagination",
+		Short: "Query groups in the given subspace with optional pagination",
 		Example: fmt.Sprintf(`
 %s query subspaces user-groups 1 --page=2 --limit=100`,
 			version.AppName),
@@ -168,7 +169,7 @@ func GetCmdQueryUserGroups() *cobra.Command {
 func GetCmdQueryUserGroupMembers() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "members [subspace-id] [group-id]",
-		Short: "Query subspaces with optional pagination",
+		Short: "Query members in the given group with optional pagination",
 		Example: fmt.Sprintf(`
 %s query subspaces user-group-members 1 1 --page=2 --limit=100`,
 			version.AppName),
@@ -209,6 +210,40 @@ func GetCmdQueryUserGroupMembers() *cobra.Command {
 
 	flags.AddQueryFlagsToCmd(cmd)
 	flags.AddPaginationFlagsToCmd(cmd, "user group members")
+
+	return cmd
+}
+
+func GetCmdQueryUserPermissions() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "permissions [subspace-id] [user]",
+		Short: "Query permissions of the given user",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			subspaceID, err := types.ParseSubspaceID(args[0])
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.UserPermissions(
+				context.Background(),
+				types.NewQueryUserPermissionsRequest(subspaceID, args[1]),
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd
 }

--- a/x/subspaces/client/cli/tx.go
+++ b/x/subspaces/client/cli/tx.go
@@ -530,7 +530,7 @@ func GetCmdSetUserPermissions() *cobra.Command {
 It is mandatory to specify at least one permission to be set.
 When specifying multiple permissions, they must be separated by a comma (,).`,
 		Example: fmt.Sprintf(`
-%s tx subspaces sset-user-permissions 1 desmos1463vltcqk6ql6zpk0g6s595jjcrzk4804hyqw7 "Write,ModerateContent,SetUserPermissions" \
+%s tx subspaces set-user-permissions 1 desmos1463vltcqk6ql6zpk0g6s595jjcrzk4804hyqw7 "Write,ModerateContent,SetUserPermissions" \
   --from alice
 `, version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Description

Closes: #XXXX

This PR added the missing query user permissions cmd.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)