### PR TITLE
fix: Fixed user query permissions CLI test

### DIFF
--- a/x/subspaces/client/cli/cli_test.go
+++ b/x/subspaces/client/cli/cli_test.go
@@ -359,6 +359,7 @@ func (s *IntegrationTestSuite) TestCmdQueryUserPermissions() {
 			expResponse: types.QueryUserPermissionsResponse{
 				Permissions: types.PermissionManageGroups,
 				Details: []types.PermissionDetail{
+					types.NewPermissionDetailGroup(0, types.PermissionNothing),
 					types.NewPermissionDetailGroup(1, types.PermissionManageGroups),
 				},
 			},


### PR DESCRIPTION
## Description

Closes: #XXXX

I don't know if it's intentional or not, but the `QueryUserPermissions` is returning also the group 0 permissions.
This because of the combination of inherited permissions. If this is intentional, than this PR fixes the failing CLI tests that were not considering that permissions in the results.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)