### PR TITLE
fix: do not allow setting permissions for self

### DIFF
--- a/.changeset/entries/32ba778bad884cf9429f4a0e2d8525170662fa1592a4b25daadc6c9ac4275e2b.yaml
+++ b/.changeset/entries/32ba778bad884cf9429f4a0e2d8525170662fa1592a4b25daadc6c9ac4275e2b.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/subspaces
+pull_request: 802
+description: Made it not possible for users to set their own permissions
+backward_compatible: true
+date: 2022-04-01T09:30:07.876291335Z

--- a/x/subspaces/keeper/msg_server.go
+++ b/x/subspaces/keeper/msg_server.go
@@ -276,6 +276,11 @@ func (k msgServer) SetUserGroupPermissions(goCtx context.Context, msg *types.Msg
 		return nil, sdkerrors.Wrapf(types.ErrPermissionDenied, "you cannot manage permissions in this subspace")
 	}
 
+	// Make sure that the user is not part of the group they want to change the permissions for
+	if k.IsMemberOfGroup(ctx, msg.SubspaceID, msg.GroupID, signer) {
+		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "cannot set the permissions for a group you are part of")
+	}
+
 	// Set the group permissions and store the group
 	group.Permissions = msg.Permissions
 	k.SaveUserGroup(ctx, group)

--- a/x/subspaces/keeper/msg_server_test.go
+++ b/x/subspaces/keeper/msg_server_test.go
@@ -914,6 +914,40 @@ func (suite *KeeperTestsuite) TestMsgServer_SetUserGroupPermissions() {
 			shouldErr: true,
 		},
 		{
+			name: "setting the permissions for a group you are part of returns error",
+			store: func(ctx sdk.Context) {
+				suite.k.SaveSubspace(ctx, types.NewSubspace(
+					1,
+					"Test subspace",
+					"This is a test subspace",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
+				))
+				suite.k.SaveUserGroup(ctx, types.NewUserGroup(
+					1,
+					1,
+					"Test group",
+					"This is a test group",
+					types.PermissionSetPermissions,
+				))
+
+				sdkAddr, err := sdk.AccAddressFromBech32("cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53")
+				suite.Require().NoError(err)
+
+				err = suite.k.AddUserToGroup(ctx, 1, 1, sdkAddr)
+				suite.Require().NoError(err)
+			},
+			msg: types.NewMsgSetUserGroupPermissions(
+				1,
+				1,
+				types.PermissionEverything,
+				"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53",
+			),
+			shouldErr: true,
+		},
+		{
 			name: "existing group is deleted properly",
 			store: func(ctx sdk.Context) {
 				suite.k.SaveSubspace(ctx, types.NewSubspace(
@@ -1548,7 +1582,7 @@ func (suite *KeeperTestsuite) TestMsgServer_SetUserPermissions() {
 					time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
 				))
 
-				sdkAddr, err := sdk.AccAddressFromBech32("cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53")
+				sdkAddr, err := sdk.AccAddressFromBech32("cosmos17ua98rre5j9ce7hfude0y5y3rh4gtqkygm8hru")
 				suite.Require().NoError(err)
 				suite.k.SetUserPermissions(ctx, 1, sdkAddr, types.PermissionSetPermissions)
 			},
@@ -1556,14 +1590,14 @@ func (suite *KeeperTestsuite) TestMsgServer_SetUserPermissions() {
 				1,
 				"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53",
 				types.PermissionWrite,
-				"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53",
+				"cosmos17ua98rre5j9ce7hfude0y5y3rh4gtqkygm8hru",
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
 					sdk.EventTypeMessage,
 					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
+					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos17ua98rre5j9ce7hfude0y5y3rh4gtqkygm8hru"),
 				),
 				sdk.NewEvent(
 					types.EventTypeSetUserPermissions,

--- a/x/subspaces/keeper/msg_server_test.go
+++ b/x/subspaces/keeper/msg_server_test.go
@@ -914,7 +914,7 @@ func (suite *KeeperTestsuite) TestMsgServer_SetUserGroupPermissions() {
 			shouldErr: true,
 		},
 		{
-			name: "setting the permissions for a group you are part of returns error",
+			name: "setting the permissions for a group you are part of returns error if not owner",
 			store: func(ctx sdk.Context) {
 				suite.k.SaveSubspace(ctx, types.NewSubspace(
 					1,
@@ -946,6 +946,58 @@ func (suite *KeeperTestsuite) TestMsgServer_SetUserGroupPermissions() {
 				"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53",
 			),
 			shouldErr: true,
+		},
+		{
+			name: "setting the permissions for a group you are part of does not return error if owner",
+			store: func(ctx sdk.Context) {
+				suite.k.SaveSubspace(ctx, types.NewSubspace(
+					1,
+					"Test subspace",
+					"This is a test subspace",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
+				))
+				suite.k.SaveUserGroup(ctx, types.NewUserGroup(
+					1,
+					1,
+					"Test group",
+					"This is a test group",
+					types.PermissionSetPermissions,
+				))
+
+				sdkAddr, err := sdk.AccAddressFromBech32("cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53")
+				suite.Require().NoError(err)
+
+				err = suite.k.AddUserToGroup(ctx, 1, 1, sdkAddr)
+				suite.Require().NoError(err)
+			},
+			msg: types.NewMsgSetUserGroupPermissions(
+				1,
+				1,
+				types.PermissionEverything,
+				"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5",
+			),
+			shouldErr: false,
+			expEvents: sdk.Events{
+				sdk.NewEvent(
+					sdk.EventTypeMessage,
+					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5"),
+				),
+				sdk.NewEvent(
+					types.EventTypeSetUserGroupPermissions,
+					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
+					sdk.NewAttribute(types.AttributeKeyUserGroupID, "1"),
+				),
+			},
+			check: func(ctx sdk.Context) {
+				group, found := suite.k.GetUserGroup(ctx, 1, 1)
+				suite.Require().True(found)
+
+				suite.Require().Equal(types.PermissionEverything, group.Permissions)
+			},
 		},
 		{
 			name: "existing group is deleted properly",

--- a/x/subspaces/simulation/operations_groups.go
+++ b/x/subspaces/simulation/operations_groups.go
@@ -224,6 +224,13 @@ func randomSetUserGroupPermissionsFields(
 	}
 	account = *acc
 
+	// Make sure the user can change this group's permissions
+	if subspace.Owner != account.Address.String() && k.IsMemberOfGroup(ctx, subspaceID, groupID, account.Address) {
+		// If the user is not the subspace owner and it's part of the user group they cannot edit the group permissions
+		skip = true
+		return
+	}
+
 	return subspaceID, groupID, permissions, account, false
 }
 

--- a/x/subspaces/simulation/operations_permissions.go
+++ b/x/subspaces/simulation/operations_permissions.go
@@ -80,5 +80,11 @@ func randomSetUserPermissionsFields(
 	}
 	account = *acc
 
+	// Make sure the signer and the user are not the same
+	if acc.Address.String() == target {
+		skip = true
+		return
+	}
+
 	return subspaceID, target, permissions, account, false
 }

--- a/x/subspaces/types/msgs.go
+++ b/x/subspaces/types/msgs.go
@@ -471,6 +471,10 @@ func (msg MsgSetUserPermissions) ValidateBasic() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address")
 	}
 
+	if msg.User == msg.Signer {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "cannot set the permissions for yourself")
+	}
+
 	return nil
 }
 

--- a/x/subspaces/types/msgs_test.go
+++ b/x/subspaces/types/msgs_test.go
@@ -783,9 +783,19 @@ func TestMsgSetUserPermissions_ValidateBasic(t *testing.T) {
 			name: "invalid signer returns error",
 			msg: types.NewMsgSetUserPermissions(
 				1,
-				"group",
+				"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5",
 				types.PermissionWrite,
 				"cosmos1m0czrla04f7rp3zg7d",
+			),
+			shouldErr: true,
+		},
+		{
+			name: "same user and signer returns error",
+			msg: types.NewMsgSetUserPermissions(
+				1,
+				"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5",
+				types.PermissionWrite,
+				"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5",
 			),
 			shouldErr: true,
 		},


### PR DESCRIPTION
## Description
This PR changes how `MsgSetUserPermissions` is validated and how `MsgSetUserGroupPermissions` is handled to make sure a user cannot set their own permissions or the permissions of a group they are part of. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)