### PR TITLE
fix: check for PermissionSetPermissions when creating a new user group

### DIFF
--- a/x/subspaces/keeper/msg_server.go
+++ b/x/subspaces/keeper/msg_server.go
@@ -161,9 +161,12 @@ func (k msgServer) CreateUserGroup(goCtx context.Context, msg *types.MsgCreateUs
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address: %s", msg.Creator)
 	}
 
-	// Check the permission to create a group
+	// Check the permissions to create a group
 	if !k.HasPermission(ctx, msg.SubspaceID, creator, types.PermissionManageGroups) {
-		return nil, sdkerrors.Wrap(types.ErrPermissionDenied, "you cannot create user groups in this subspace")
+		return nil, sdkerrors.Wrap(types.ErrPermissionDenied, "you cannot manage user groups in this subspace")
+	}
+	if !k.HasPermission(ctx, msg.SubspaceID, creator, types.PermissionSetPermissions) {
+		return nil, sdkerrors.Wrap(types.ErrPermissionDenied, "you cannot manage permissions in this subspace")
 	}
 
 	// Get the next group ID

--- a/x/subspaces/keeper/msg_server_test.go
+++ b/x/subspaces/keeper/msg_server_test.go
@@ -554,7 +554,7 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateUserGroup() {
 			shouldErr: true,
 		},
 		{
-			name: "user without permission returns error",
+			name: "user without PermissionManageGroups returns error",
 			store: func(ctx sdk.Context) {
 				suite.k.SaveSubspace(ctx, types.NewSubspace(
 					1,
@@ -565,6 +565,32 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateUserGroup() {
 					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
 					time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
 				))
+			},
+			msg: types.NewMsgCreateUserGroup(
+				1,
+				"group",
+				"description",
+				types.PermissionWrite,
+				"cosmos1y4emx0mm4ncva9mnv9yvjrm7nrq3psvmwhk9ll",
+			),
+			shouldErr: true,
+		},
+		{
+			name: "user without PermissionSetPermissions returns error",
+			store: func(ctx sdk.Context) {
+				suite.k.SaveSubspace(ctx, types.NewSubspace(
+					1,
+					"Test subspace",
+					"This is a test subspace",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69",
+					time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
+				))
+
+				sdkAddr, err := sdk.AccAddressFromBech32("cosmos1y4emx0mm4ncva9mnv9yvjrm7nrq3psvmwhk9ll")
+				suite.Require().NoError(err)
+				suite.k.SetUserPermissions(ctx, 1, sdkAddr, types.PermissionManageGroups)
 			},
 			msg: types.NewMsgCreateUserGroup(
 				1,
@@ -599,7 +625,7 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateUserGroup() {
 
 				sdkAddr, err := sdk.AccAddressFromBech32("cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53")
 				suite.Require().NoError(err)
-				suite.k.SetUserPermissions(ctx, 1, sdkAddr, types.PermissionManageGroups)
+				suite.k.SetUserPermissions(ctx, 1, sdkAddr, types.CombinePermissions(types.PermissionManageGroups, types.PermissionSetPermissions))
 			},
 			msg: types.NewMsgCreateUserGroup(
 				1,

--- a/x/subspaces/simulation/operations_groups.go
+++ b/x/subspaces/simulation/operations_groups.go
@@ -76,7 +76,7 @@ func randomCreateUserGroupFields(
 	})
 
 	// Get a signer
-	signers, _ := k.GetUsersWithPermission(ctx, subspace.ID, types.PermissionManageGroups)
+	signers, _ := k.GetUsersWithPermission(ctx, subspace.ID, types.CombinePermissions(types.PermissionManageGroups, types.PermissionSetPermissions))
 	acc := GetAccount(RandomAddress(r, signers), accs)
 	if acc == nil {
 		// Skip the operation without error as the account is not valid


### PR DESCRIPTION

## Description
This PR adds the check for `PermissionSetPermissions` when creating a new user group, as per https://github.com/desmos-labs/desmos/pull/802#issuecomment-1087491235.

Special review required by @manu0466 to make sure we fixed the bug.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)