### PR TITLE
fix: fix CLI commands args number

### DIFF
--- a/.changeset/entries/8fea7719728d408975e08ec2ca629f6241c68afe263cc5897d7ebcb0856b4520.yaml
+++ b/.changeset/entries/8fea7719728d408975e08ec2ca629f6241c68afe263cc5897d7ebcb0856b4520.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/profiles
+pull_request: 832
+description: Fixed the CLI commands expected number of arguments
+backward_compatible: true
+date: 2022-04-22T05:53:09.198350555Z

--- a/x/profiles/client/cli/cli_chain_links.go
+++ b/x/profiles/client/cli/cli_chain_links.go
@@ -26,7 +26,7 @@ func GetCmdLinkChainAccount() *cobra.Command {
 The link data must be supplied via a JSON file.
 
 Example:
-$ %s tx profiles link <path/to/data.json> --from=<key_or_address>
+$ %s tx profiles link-chain <path/to/data.json> --from=<key_or_address>
 
 Where data.json contains:
 
@@ -121,7 +121,7 @@ func GetCmdQueryChainLinks() *cobra.Command {
 %s query profiles chain-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "cosmos"
 %s query profiles chain-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "cosmos" cosmos19s242dxhxgzlsdmfjjg38jgfwhxca7569g84sw
 `, version.AppName, version.AppName, version.AppName, version.AppName, version.AppName),
-		Args: cobra.RangeArgs(0, 1),
+		Args: cobra.RangeArgs(0, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {

--- a/x/profiles/client/cli/cli_dtag_requests.go
+++ b/x/profiles/client/cli/cli_dtag_requests.go
@@ -81,8 +81,10 @@ func GetCmdCancelDTagTransfer() *cobra.Command {
 // GetCmdAcceptDTagTransfer returns the command to accept a DTag transfer request
 func GetCmdAcceptDTagTransfer() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "accept-dtag-transfer-request [DTag] [address]",
-		Short: `Accept a DTag transfer request made by the user with the given address.
+		Use:   "accept-dtag-transfer-request [DTag] [address]",
+		Short: `Accept a DTag transfer request made by another user towards you`,
+		Long: `Accept a DTag transfer request made by the user with the given address.
+
 When accepting the request, you can specify the request recipient DTag as your new DTag. 
 If this happens, your DTag and the other user's one will be effectively swapped.`,
 		Example: fmt.Sprintf(`%s tx profiles accept-dtag-transfer-request "leoDiCaprio" desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud`, version.AppName),


### PR DESCRIPTION
## Description

This PR fixes some CLI commands args number to properly match the expected ones.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [x] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [x] reviewed tests and test coverage
- [ ] manually tested (if applicable)