### PR TITLE
fix: avoid multiple min fees for same message type

### DIFF
--- a/x/fees/types/params.go
+++ b/x/fees/types/params.go
@@ -60,7 +60,21 @@ func ValidateMinFeesParam(i interface{}) error {
 		if err := fee.Validate(); err != nil {
 			return err
 		}
+
+		if isMinFeeDuplicated(fee, fees) {
+			return fmt.Errorf("duplicated min fee for message type %s", fee.MessageType)
+		}
 	}
 
 	return nil
+}
+
+func isMinFeeDuplicated(value MinFee, minFees []MinFee) bool {
+	var count = 0
+	for _, fee := range minFees {
+		if fee.MessageType == value.MessageType {
+			count++
+		}
+	}
+	return count > 1
 }

--- a/x/fees/types/params_test.go
+++ b/x/fees/types/params_test.go
@@ -18,9 +18,16 @@ func TestValidateParams(t *testing.T) {
 		shouldErr bool
 	}{
 		{
-			name: "invalid amount returns error",
+			name: "invalid type returns error",
 			params: types.NewParams([]types.MinFee{
 				types.NewMinFee("", sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(1)))),
+			}),
+			shouldErr: true,
+		},
+		{
+			name: "invalid amount returns error",
+			params: types.NewParams([]types.MinFee{
+				types.NewMinFee("/desmos.profiles.v2.SaveProfile", sdk.Coins{sdk.Coin{Denom: "", Amount: sdk.NewInt(1)}}),
 			}),
 			shouldErr: true,
 		},

--- a/x/fees/types/params_test.go
+++ b/x/fees/types/params_test.go
@@ -18,15 +18,31 @@ func TestValidateParams(t *testing.T) {
 		shouldErr bool
 	}{
 		{
-			name: "invalid params returns error",
+			name: "invalid amount returns error",
 			params: types.NewParams([]types.MinFee{
 				types.NewMinFee("", sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(1)))),
 			}),
 			shouldErr: true,
 		},
 		{
+			name: "duplicated min fee returns error",
+			params: types.NewParams([]types.MinFee{
+				types.NewMinFee("/desmos.profiles.v2.SaveProfile", sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(1)))),
+				types.NewMinFee("/desmos.profiles.v2.SaveProfile", sdk.NewCoins(sdk.NewCoin("photino", sdk.NewInt(1)))),
+			}),
+			shouldErr: true,
+		},
+		{
 			name:      "default params returns no error",
 			params:    types.DefaultParams(),
+			shouldErr: false,
+		},
+		{
+			name: "custom params returns no error",
+			params: types.NewParams([]types.MinFee{
+				types.NewMinFee("/desmos.profiles.v2.SaveProfile", sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(1)))),
+				types.NewMinFee("/desmos.profiles.v2.CreateChainLink", sdk.NewCoins(sdk.NewCoin("photino", sdk.NewInt(1)))),
+			}),
 			shouldErr: false,
 		},
 	}


### PR DESCRIPTION
## Description

This PR adds a check to make sure that there cannot be multiple min fees for the same message type inside the `x/fees` on-chain parameters.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)