### PR TITLE
fix: add missing profiles commands

### DIFF
--- a/.changeset/entries/68d07218bf30b0b984be4c29146eb71f915df11721ab81b8eec2595ab493ae4d.yaml
+++ b/.changeset/entries/68d07218bf30b0b984be4c29146eb71f915df11721ab81b8eec2595ab493ae4d.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/profiles
+pull_request: 840
+description: Added missing profiles query commands
+backward_compatible: true
+date: 2022-04-25T09:33:37.0662913Z

--- a/x/profiles/client/cli/cli_app_links.go
+++ b/x/profiles/client/cli/cli_app_links.go
@@ -143,8 +143,8 @@ func GetCmdQueryApplicationsLinks() *cobra.Command {
 		Short: "Get all the application links with optional user address, application, username and pagination",
 		Example: fmt.Sprintf(`%s query profiles app-links --page=2 --limit=100
 %s query profiles app-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud
-%s query app-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "twitter"
-%s query app-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "twitter" "twitter_user"
+%s query profiles app-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "twitter"
+%s query profiles app-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "twitter" "twitter_user"
 `, version.AppName, version.AppName, version.AppName, version.AppName),
 		Args: cobra.RangeArgs(0, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -188,6 +188,56 @@ func GetCmdQueryApplicationsLinks() *cobra.Command {
 
 	flags.AddQueryFlagsToCmd(cmd)
 	flags.AddPaginationFlagsToCmd(cmd, "app links")
+
+	return cmd
+}
+
+// GetCmdQueryApplicationLinkOwners returns the command allowing to query the application link owners, optionally associated with a target
+func GetCmdQueryApplicationLinkOwners() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "app-links [[application]] [[username]]",
+		Short: "Get all the application link owners with optional application, username and pagination",
+		Example: fmt.Sprintf(`%s query profiles app-links --page=2 --limit=100
+%s query profiles app-links "twitter"
+%s query profiles app-links "twitter" "twitter_user"
+`, version.AppName, version.AppName, version.AppName),
+		Args: cobra.RangeArgs(0, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			var application string
+			if len(args) > 0 {
+				application = args[0]
+			}
+
+			var username string
+			if len(args) > 1 {
+				username = args[1]
+			}
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.ApplicationLinkOwners(
+				context.Background(),
+				types.NewQueryApplicationLinkOwnersRequest(application, username, pageReq),
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "app link owners")
 
 	return cmd
 }

--- a/x/profiles/client/cli/cli_app_links.go
+++ b/x/profiles/client/cli/cli_app_links.go
@@ -195,11 +195,11 @@ func GetCmdQueryApplicationsLinks() *cobra.Command {
 // GetCmdQueryApplicationLinkOwners returns the command allowing to query the application link owners, optionally associated with a target
 func GetCmdQueryApplicationLinkOwners() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "app-links [[application]] [[username]]",
+		Use:   "app-link-owners [[application]] [[username]]",
 		Short: "Get all the application link owners with optional application, username and pagination",
-		Example: fmt.Sprintf(`%s query profiles app-links --page=2 --limit=100
-%s query profiles app-links "twitter"
-%s query profiles app-links "twitter" "twitter_user"
+		Example: fmt.Sprintf(`%s query profiles app-link-owners --page=2 --limit=100
+%s query profiles app-link-owners "twitter"
+%s query profiles app-link-owners "twitter" "twitter_user"
 `, version.AppName, version.AppName, version.AppName),
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/profiles/client/cli/cli_chain_links.go
+++ b/x/profiles/client/cli/cli_chain_links.go
@@ -115,8 +115,8 @@ func GetCmdQueryChainLinks() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "chain-links [[user]] [[chain_name]] [[target]]",
 		Short: "Retrieve all chain links with optional user address, chain name, target and pagination",
-		Example: fmt.Sprintf(`%s query chain-links chain-links
-%s query chain-links chain-links --page=2 --limit=100
+		Example: fmt.Sprintf(`%s query profiles chain-links
+%s query profiles chain-links --page=2 --limit=100
 %s query profiles chain-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud
 %s query profiles chain-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "cosmos"
 %s query profiles chain-links desmos13p5pamrljhza3fp4es5m3llgmnde5fzcpq6nud "cosmos" cosmos19s242dxhxgzlsdmfjjg38jgfwhxca7569g84sw
@@ -162,6 +162,57 @@ func GetCmdQueryChainLinks() *cobra.Command {
 	}
 
 	flags.AddPaginationFlagsToCmd(cmd, "chain links")
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryChainLinkOwners returns the command allowing to query the chain link owners, optionally associated with a target
+func GetCmdQueryChainLinkOwners() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "chain-link-owners [[chain_name]] [[target]]",
+		Short: "Retrieve all owners of chain links with optional chain name, target and pagination",
+		Example: fmt.Sprintf(`%s query profiles chain-link-owners
+%s query profiles chain-link-owners --page=2 --limit=100
+%s query profiles chain-link-owners "cosmos"
+%s query profiles chain-link-owners "cosmos" cosmos19s242dxhxgzlsdmfjjg38jgfwhxca7569g84sw
+`, version.AppName, version.AppName, version.AppName, version.AppName),
+		Args: cobra.RangeArgs(0, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			var chainName string
+			if len(args) > 0 {
+				chainName = args[0]
+			}
+
+			var target string
+			if len(args) > 1 {
+				target = args[1]
+			}
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.ChainLinkOwners(
+				context.Background(),
+				types.NewQueryChainLinkOwnersRequest(chainName, target, pageReq),
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddPaginationFlagsToCmd(cmd, "chain link owners")
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd

--- a/x/profiles/client/cli/cli_chain_links.go
+++ b/x/profiles/client/cli/cli_chain_links.go
@@ -171,7 +171,7 @@ func GetCmdQueryChainLinks() *cobra.Command {
 func GetCmdQueryChainLinkOwners() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "chain-link-owners [[chain_name]] [[target]]",
-		Short: "Retrieve all owners of chain links with optional chain name, target and pagination",
+		Short: "Retrieve all chain link owners with optional chain name, target and pagination",
 		Example: fmt.Sprintf(`%s query profiles chain-link-owners
 %s query profiles chain-link-owners --page=2 --limit=100
 %s query profiles chain-link-owners "cosmos"

--- a/x/profiles/client/cli/cli_chain_links_test.go
+++ b/x/profiles/client/cli/cli_chain_links_test.go
@@ -104,6 +104,99 @@ func (s *IntegrationTestSuite) TestCmdQueryChainLinks() {
 	}
 }
 
+func (s *IntegrationTestSuite) TestCmdQueryChainLinkOwners() {
+	val := s.network.Validators[0]
+	target := s.testChainLinkAccount.GetBech32ChainLink(
+		"cosmos1ftkjv8njvkekk00ehwdfl5sst8zgdpenjfm4hs",
+		time.Date(2019, 1, 1, 00, 00, 00, 000, time.UTC),
+	).GetAddressData().GetValue()
+
+	useCases := []struct {
+		name           string
+		args           []string
+		shouldErr      bool
+		expectedOutput types.QueryChainLinkOwnersResponse
+	}{
+		{
+			name: "existing chain link owners are returned properly",
+			args: []string{
+				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+			},
+			shouldErr: false,
+			expectedOutput: types.QueryChainLinkOwnersResponse{
+				Owners: []types.QueryChainLinkOwnersResponse_ChainLinkOwnerDetails{
+					{
+						User:      "cosmos1ftkjv8njvkekk00ehwdfl5sst8zgdpenjfm4hs",
+						ChainName: "cosmos",
+						Target:    target,
+					},
+				},
+				Pagination: &query.PageResponse{
+					NextKey: nil,
+					Total:   0,
+				},
+			},
+		},
+		{
+			name: "empty array is returned properly",
+			args: []string{
+				"desmos",
+				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+			},
+			shouldErr: false,
+			expectedOutput: types.QueryChainLinkOwnersResponse{
+				Owners: []types.QueryChainLinkOwnersResponse_ChainLinkOwnerDetails{},
+				Pagination: &query.PageResponse{
+					NextKey: nil,
+					Total:   0,
+				},
+			},
+		},
+		{
+			name: "existing chain link owners of the given chain name are returned properly",
+			args: []string{
+				"cosmos",
+				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+			},
+			shouldErr: false,
+			expectedOutput: types.QueryChainLinkOwnersResponse{
+				Owners: []types.QueryChainLinkOwnersResponse_ChainLinkOwnerDetails{
+					{
+						User:      "cosmos1ftkjv8njvkekk00ehwdfl5sst8zgdpenjfm4hs",
+						ChainName: "cosmos",
+						Target:    target,
+					},
+				},
+				Pagination: &query.PageResponse{
+					NextKey: nil,
+					Total:   0,
+				},
+			},
+		},
+	}
+
+	for _, uc := range useCases {
+		uc := uc
+
+		s.Run(uc.name, func() {
+			cmd := cli.GetCmdQueryChainLinkOwners()
+			clientCtx := val.ClientCtx
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, uc.args)
+
+			if uc.shouldErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+
+				var response types.QueryChainLinkOwnersResponse
+				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
+				s.Require().Equal(uc.expectedOutput.Pagination, response.Pagination)
+				s.Require().Equal(uc.expectedOutput.Owners, response.Owners)
+			}
+		})
+	}
+}
+
 func (s *IntegrationTestSuite) TestCmdLinkChainAccount() {
 	cliCtx := s.network.Validators[0].ClientCtx
 	cliCtx.Keyring = s.keyBase

--- a/x/profiles/client/cli/query.go
+++ b/x/profiles/client/cli/query.go
@@ -24,6 +24,7 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdQueryDTagRequests(),
 		GetCmdQueryParams(),
 		GetCmdQueryChainLinks(),
+		GetCmdQueryChainLinkOwners(),
 		GetCmdQueryApplicationsLinks(),
 	)
 	return profileQueryCmd

--- a/x/profiles/client/cli/query.go
+++ b/x/profiles/client/cli/query.go
@@ -26,6 +26,7 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdQueryChainLinks(),
 		GetCmdQueryChainLinkOwners(),
 		GetCmdQueryApplicationsLinks(),
+		GetCmdQueryApplicationLinkOwners(),
 	)
 	return profileQueryCmd
 }


### PR DESCRIPTION
## Description
This PR adds missing profiles commands, `GetQueryChainLinkOwners` and `GetQueryApplicationLinkOnwers`.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)