### PR TITLE
fix: fix default node home when exporting the state

### DIFF
--- a/.changeset/entries/d4afbea9357029666b3c020a5fecbced824a4ceca62ae3c2d196c476e29d03a8.yaml
+++ b/.changeset/entries/d4afbea9357029666b3c020a5fecbced824a4ceca62ae3c2d196c476e29d03a8.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: other
+pull_request: 843
+description: Fixed the default home path inside the export command
+backward_compatible: true
+date: 2022-04-26T10:38:44.43005827Z

--- a/app/desmos/cmd/root.go
+++ b/app/desmos/cmd/root.go
@@ -298,13 +298,25 @@ func createDesmosappAndExport(
 	encCfg.Marshaler = codec.NewProtoCodec(encCfg.InterfaceRegistry)
 	var desmosApp *app.DesmosApp
 	if height != -1 {
-		desmosApp = app.NewDesmosApp(logger, db, traceStore, false, map[int64]bool{}, "", uint(1), encCfg, appOpts)
+		desmosApp = app.NewDesmosApp(
+			logger, db, traceStore, false, map[int64]bool{},
+			cast.ToString(appOpts.Get(flags.FlagHome)),
+			uint(1),
+			encCfg,
+			appOpts,
+		)
 		err := desmosApp.LoadHeight(height)
 		if err != nil {
 			return servertypes.ExportedApp{}, err
 		}
 	} else {
-		desmosApp = app.NewDesmosApp(logger, db, traceStore, true, map[int64]bool{}, "", uint(1), encCfg, appOpts)
+		desmosApp = app.NewDesmosApp(
+			logger, db, traceStore, true, map[int64]bool{},
+			cast.ToString(appOpts.Get(flags.FlagHome)),
+			uint(1),
+			encCfg,
+			appOpts,
+		)
 	}
 
 	return desmosApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs)


### PR DESCRIPTION
## Description

This PR fixes the initialization of the app when running the `export` command so that CosmWASM files can be read properly and its state can be exported correctly. Thanks to @webmaster128 for helping debugging this

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)