### PR TITLE
fix!: add Amino support for x/subspaces messages

### DIFF
--- a/.changeset/entries/2ceedb22572eba8499b4b7abf8c4b38789a979fa8a852a3537dc9cba4b81bc16.yaml
+++ b/.changeset/entries/2ceedb22572eba8499b4b7abf8c4b38789a979fa8a852a3537dc9cba4b81bc16.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/subspaces
+pull_request: 849
+description: Added correct Amino encoding support
+backward_compatible: false
+date: 2022-04-29T06:42:21.929594578Z

--- a/x/subspaces/types/codec.go
+++ b/x/subspaces/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
@@ -46,3 +47,8 @@ var (
 	// defined at the application level.
 	AminoCodec = codec.NewAminoCodec(amino)
 )
+
+func init() {
+	RegisterLegacyAminoCodec(amino)
+	cryptocodec.RegisterCrypto(amino)
+}

--- a/x/subspaces/types/msgs_test.go
+++ b/x/subspaces/types/msgs_test.go
@@ -95,7 +95,7 @@ func TestMsgCreateSubspace_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgCreateSubspace_GetSignBytes(t *testing.T) {
-	expected := `{"creator":"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69","description":"This is a test subspace","name":"Test subspace","owner":"cosmos1lv3e0l66rr68k5l74mnrv4j9kyny6cz27pvnez","treasury":"cosmos1vkuuth0rak58x36m7wuzj7ztttxh26fhqcfxm0"}`
+	expected := `{"type":"desmos/MsgCreateSubspace","value":{"creator":"cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69","description":"This is a test subspace","name":"Test subspace","owner":"cosmos1lv3e0l66rr68k5l74mnrv4j9kyny6cz27pvnez","treasury":"cosmos1vkuuth0rak58x36m7wuzj7ztttxh26fhqcfxm0"}}`
 	require.Equal(t, expected, string(msgCreateSubspace.GetSignBytes()))
 }
 
@@ -173,7 +173,7 @@ func TestMsgEditSubspace_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgEditSubspace_GetSignBytes(t *testing.T) {
-	expected := `{"description":"This is a new description","name":"This is a new name","owner":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","treasury":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5"}`
+	expected := `{"type":"desmos/MsgEditSubspace","value":{"description":"This is a new description","name":"This is a new name","owner":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","treasury":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5"}}`
 	require.Equal(t, expected, string(msgEditSubspace.GetSignBytes()))
 }
 
@@ -319,7 +319,7 @@ func TestMsgCreateUserGroup_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgCreateUserGroup_GetSignBytes(t *testing.T) {
-	expected := `{"creator":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","default_permissions":1,"description":"Description","name":"Group","subspace_id":"1"}`
+	expected := `{"type":"desmos/MsgCreateUserGroup","value":{"creator":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","default_permissions":1,"description":"Description","name":"Group","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgCreateUserGroup.GetSignBytes()))
 }
 
@@ -394,7 +394,7 @@ func TestMsgEditUserGroup_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgEditUserGroup_GetSignBytes(t *testing.T) {
-	expected := `{"description":"Description","group_id":1,"name":"Group","signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}`
+	expected := `{"type":"desmos/MsgEditUserGroup","value":{"description":"Description","group_id":1,"name":"Group","signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgEditUserGroup.GetSignBytes()))
 }
 
@@ -466,7 +466,7 @@ func TestMsgSetUserGroupPermissions_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgSetUserGroupPermissions_GetSignBytes(t *testing.T) {
-	expected := `{"group_id":1,"permissions":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}`
+	expected := `{"type":"desmos/MsgSetUserGroupPermissions","value":{"group_id":1,"permissions":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgSetUserGroupPermissions.GetSignBytes()))
 }
 
@@ -544,7 +544,7 @@ func TestMsgDeleteUserGroup_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgDeleteUserGroup_GetSignBytes(t *testing.T) {
-	expected := `{"group_id":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}`
+	expected := `{"type":"desmos/MsgDeleteUserGroup","value":{"group_id":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgDeleteUserGroup.GetSignBytes()))
 }
 
@@ -636,7 +636,7 @@ func TestMsgAddUserToUserGroup_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgAddUserToUserGroup_GetSignBytes(t *testing.T) {
-	expected := `{"group_id":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","user":"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"}`
+	expected := `{"type":"desmos/MsgAddUserToUserGroup","value":{"group_id":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","user":"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"}}`
 	require.Equal(t, expected, string(msgAddUserToGroup.GetSignBytes()))
 }
 
@@ -728,7 +728,7 @@ func TestMsgRemoveUserFromUserGroup_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgRemoveUserFromUserGroup_GetSignBytes(t *testing.T) {
-	expected := `{"group_id":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","user":"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"}`
+	expected := `{"type":"desmos/MsgRemoveUserFromUserGroup","value":{"group_id":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","user":"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"}}`
 	require.Equal(t, expected, string(msgRemoveUserFromUserGroup.GetSignBytes()))
 }
 
@@ -819,7 +819,7 @@ func TestMsgSetUserPermissions_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgSetUserPermissions_GetSignBytes(t *testing.T) {
-	expected := `{"permissions":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","user":"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"}`
+	expected := `{"type":"desmos/MsgSetUserPermissions","value":{"permissions":1,"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1","user":"cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"}}`
 	require.Equal(t, expected, string(msgSetUserPermissions.GetSignBytes()))
 }
 


### PR DESCRIPTION
## Description

This PR adds Amino encoding supporrt for `x/subspaces` messages

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)