### PR TITLE
fix: fix MultiSignatureData deserialization

### DIFF
--- a/x/profiles/types/models_chain_links.go
+++ b/x/profiles/types/models_chain_links.go
@@ -315,6 +315,19 @@ var _ SignatureData = &MultiSignatureData{}
 // isSignatureData implements SignatureData
 func (s *MultiSignatureData) isSignatureData() {}
 
+// UnpackInterfaces implements codectypes.UnpackInterfacesMessage
+func (s *MultiSignatureData) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	for _, signature := range s.Signatures {
+		var signatureData SignatureData
+		err := unpacker.UnpackAny(signature, &signatureData)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 // AddressData is an interface representing a generic external chain address


### PR DESCRIPTION
## Description

This PR fixes a deserialization issue with `MultiSignatureData` due to the fact it missed the `UnpackInterfaces` method.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)