### PR TITLE
docs: updated Swagger config and UI

### DIFF
--- a/client/docs/config.json
+++ b/client/docs/config.json
@@ -7,13 +7,29 @@
   },
   "apis": [
     {
-      "url": "./tmp-swagger-gen/desmos/profiles/v2/query.swagger.json"
+      "url": "./tmp-swagger-gen/desmos/profiles/v2/query.swagger.json",
+      "operationIds": {
+        "rename": {
+          "Params": "ProfilesParams"
+        }
+      }
+    },
+    {
+      "url": "./tmp-swagger-gen/desmos/relationships/v1/query.swagger.json"
     },
     {
       "url": "./tmp-swagger-gen/desmos/subspaces/v1/query.swagger.json"
     },
     {
-      "url": "./tmp-swagger-gen/desmos/relationships/v1/query.swagger.json"
+      "url": "./tmp-swagger-gen/desmos/fees/v1/query.swagger.json",
+      "operationIds": {
+        "rename": {
+          "Params": "FeesParams"
+        }
+      }
+    },
+    {
+      "url": "./tmp-swagger-gen/desmos/supply/v1/query.swagger.json"
     }
   ]
 }

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -2670,7 +2670,7 @@ paths:
   /desmos/profiles/v2/params:
     get:
       summary: Params queries the profiles module params
-      operationId: Params
+      operationId: ProfilesParams
       responses:
         '200':
           description: A successful response.
@@ -3363,6 +3363,687 @@ paths:
           type: string
       tags:
         - Query
+  /desmos/relationships/v1/blocks:
+    get:
+      summary: |-
+        Blocks queries the blocks for the given user, if provided.
+        Otherwise, it queries all the stored blocks.
+      operationId: Blocks
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              blocks:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    blocker:
+                      type: string
+                      title: >-
+                        Blocker represents the address of the user blocking
+                        another one
+                    blocked:
+                      type: string
+                      title: Blocked represents the address of the blocked user
+                    reason:
+                      type: string
+                      description: >-
+                        Reason represents the optional reason the user has been
+                        blocked for.
+                    subspace_id:
+                      type: string
+                      format: uint64
+                      title: >-
+                        SubspaceID represents the ID of the subspace inside
+                        which the user should
+
+                        be blocked
+                  description: >-
+                    UserBlock represents the fact that the Blocker has blocked
+                    the given Blocked
+
+                    user.
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    title: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+            description: |-
+              QueryBlocksResponse is the response type for the Query/Blocks RPC
+              method.
+        default:
+          description: An unexpected error response
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := ptypes.MarshalAny(foo)
+                         ...
+                         foo := &pb.Foo{}
+                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: subspace_id
+          description: subspace to query the blocks for.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: blocker
+          description: optional address of the blocker to query the blocks for.
+          in: query
+          required: false
+          type: string
+        - name: blocked
+          description: >-
+            optional address of the blocked user to query the block for (used
+            only if
+
+            the blocker is provided).
+          in: query
+          required: false
+          type: string
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+          format: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+          format: boolean
+      tags:
+        - Query
+  /desmos/relationships/v1/relationships:
+    get:
+      summary: >-
+        Relationships queries all relationships present inside a specific
+        subspace
+      operationId: Relationships
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              relationships:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    creator:
+                      type: string
+                      title: Creator represents the creator of the relationship
+                    counterparty:
+                      type: string
+                      title: >-
+                        Counterparty represents the other user involved in the
+                        relationship
+                    subspace_id:
+                      type: string
+                      format: uint64
+                      title: >-
+                        SubspaceID represents the id of the subspace for which
+                        the relationship is
+
+                        valid
+                  description: >-
+                    Relationship is the struct of a relationship.
+
+                    It represent the concept of "follow" of traditional social
+                    networks.
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    title: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+            description: |-
+              QueryRelationshipsResponse is the response type for the
+              Query/Relationships RPC method.
+        default:
+          description: An unexpected error response
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := ptypes.MarshalAny(foo)
+                         ...
+                         foo := &pb.Foo{}
+                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: subspace_id
+          description: subspace to query the relationships for.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: user
+          description: optional address of the user for which to query the relationships.
+          in: query
+          required: false
+          type: string
+        - name: counterparty
+          description: >-
+            optional address of the counterparty of the relationships (used only
+            if the
+
+            user is provided).
+          in: query
+          required: false
+          type: string
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+          format: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+          format: boolean
+      tags:
+        - Query
   /desmos/subspaces/v1/subspaces:
     get:
       summary: Subspaces queries all the subspaces inside Desmos
@@ -4051,79 +4732,51 @@ paths:
           type: string
       tags:
         - Query
-  /desmos/relationships/v1/blocks:
+  /desmos/fees/v1/params:
     get:
-      summary: |-
-        Blocks queries the blocks for the given user, if provided.
-        Otherwise, it queries all the stored blocks.
-      operationId: Blocks
+      summary: Params queries the fees module params
+      operationId: FeesParams
       responses:
         '200':
           description: A successful response.
           schema:
             type: object
             properties:
-              blocks:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    blocker:
-                      type: string
-                      title: >-
-                        Blocker represents the address of the user blocking
-                        another one
-                    blocked:
-                      type: string
-                      title: Blocked represents the address of the blocked user
-                    reason:
-                      type: string
-                      description: >-
-                        Reason represents the optional reason the user has been
-                        blocked for.
-                    subspace_id:
-                      type: string
-                      format: uint64
-                      title: >-
-                        SubspaceID represents the ID of the subspace inside
-                        which the user should
-
-                        be blocked
-                  description: >-
-                    UserBlock represents the fact that the Blocker has blocked
-                    the given Blocked
-
-                    user.
-              pagination:
+              params:
                 type: object
                 properties:
-                  next_key:
-                    type: string
-                    format: byte
-                    title: |-
-                      next_key is the key to be passed to PageRequest.key to
-                      query the next page most efficiently
-                  total:
-                    type: string
-                    format: uint64
-                    title: >-
-                      total is total number of results available if
-                      PageRequest.count_total
+                  min_fees:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        message_type:
+                          type: string
+                        amount:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              denom:
+                                type: string
+                              amount:
+                                type: string
+                            description: >-
+                              Coin defines a token with a denomination and an
+                              amount.
 
-                      was set, its value is undefined otherwise
-                description: >-
-                  PageResponse is to be embedded in gRPC response messages where
-                  the
 
-                  corresponding request message has used PageRequest.
+                              NOTE: The amount field is an Int which implements
+                              the custom method
 
-                   message SomeResponse {
-                           repeated Bar results = 1;
-                           PageResponse page = 2;
-                   }
-            description: |-
-              QueryBlocksResponse is the response type for the Query/Blocks RPC
-              method.
+                              signatures required by gogoproto.
+                      title: >-
+                        MinFee contains the minimum amount of coins that should
+                        be paid as a fee for
+
+                        each message of the specific type sent
+                title: Params contains the parameters for the fees module
+            title: QueryParamsResponse is the response type for the Query/Params RPC
         default:
           description: An unexpected error response
           schema:
@@ -4143,325 +4796,32 @@ paths:
                   properties:
                     type_url:
                       type: string
-                      description: >-
-                        A URL/resource name that uniquely identifies the type of
-                        the serialized
-
-                        protocol buffer message. This string must contain at
-                        least
-
-                        one "/" character. The last segment of the URL's path
-                        must represent
-
-                        the fully qualified name of the type (as in
-
-                        `path/google.protobuf.Duration`). The name should be in
-                        a canonical form
-
-                        (e.g., leading "." is not accepted).
-
-
-                        In practice, teams usually precompile into the binary
-                        all types that they
-
-                        expect it to use in the context of Any. However, for
-                        URLs which use the
-
-                        scheme `http`, `https`, or no scheme, one can optionally
-                        set up a type
-
-                        server that maps type URLs to message definitions as
-                        follows:
-
-
-                        * If no scheme is provided, `https` is assumed.
-
-                        * An HTTP GET on the URL must yield a
-                        [google.protobuf.Type][]
-                          value in binary format, or produce an error.
-                        * Applications are allowed to cache lookup results based
-                        on the
-                          URL, or have them precompiled into a binary to avoid any
-                          lookup. Therefore, binary compatibility needs to be preserved
-                          on changes to types. (Use versioned type names to manage
-                          breaking changes.)
-
-                        Note: this functionality is not currently available in
-                        the official
-
-                        protobuf release, and it is not used for type URLs
-                        beginning with
-
-                        type.googleapis.com.
-
-
-                        Schemes other than `http`, `https` (or the empty scheme)
-                        might be
-
-                        used with implementation specific semantics.
                     value:
                       type: string
                       format: byte
-                      description: >-
-                        Must be a valid serialized protocol buffer of the above
-                        specified type.
-                  description: >-
-                    `Any` contains an arbitrary serialized protocol buffer
-                    message along with a
-
-                    URL that describes the type of the serialized message.
-
-
-                    Protobuf library provides support to pack/unpack Any values
-                    in the form
-
-                    of utility functions or additional generated methods of the
-                    Any type.
-
-
-                    Example 1: Pack and unpack a message in C++.
-
-                        Foo foo = ...;
-                        Any any;
-                        any.PackFrom(foo);
-                        ...
-                        if (any.UnpackTo(&foo)) {
-                          ...
-                        }
-
-                    Example 2: Pack and unpack a message in Java.
-
-                        Foo foo = ...;
-                        Any any = Any.pack(foo);
-                        ...
-                        if (any.is(Foo.class)) {
-                          foo = any.unpack(Foo.class);
-                        }
-
-                     Example 3: Pack and unpack a message in Python.
-
-                        foo = Foo(...)
-                        any = Any()
-                        any.Pack(foo)
-                        ...
-                        if any.Is(Foo.DESCRIPTOR):
-                          any.Unpack(foo)
-                          ...
-
-                     Example 4: Pack and unpack a message in Go
-
-                         foo := &pb.Foo{...}
-                         any, err := ptypes.MarshalAny(foo)
-                         ...
-                         foo := &pb.Foo{}
-                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
-                           ...
-                         }
-
-                    The pack methods provided by protobuf library will by
-                    default use
-
-                    'type.googleapis.com/full.type.name' as the type URL and the
-                    unpack
-
-                    methods only use the fully qualified type name after the
-                    last '/'
-
-                    in the type URL, for example "foo.bar.com/x/y.z" will yield
-                    type
-
-                    name "y.z".
-
-
-
-                    JSON
-
-                    ====
-
-                    The JSON representation of an `Any` value uses the regular
-
-                    representation of the deserialized, embedded message, with
-                    an
-
-                    additional field `@type` which contains the type URL.
-                    Example:
-
-                        package google.profile;
-                        message Person {
-                          string first_name = 1;
-                          string last_name = 2;
-                        }
-
-                        {
-                          "@type": "type.googleapis.com/google.profile.Person",
-                          "firstName": <string>,
-                          "lastName": <string>
-                        }
-
-                    If the embedded message type is well-known and has a custom
-                    JSON
-
-                    representation, that representation will be embedded adding
-                    a field
-
-                    `value` which holds the custom JSON in addition to the
-                    `@type`
-
-                    field. Example (for message [google.protobuf.Duration][]):
-
-                        {
-                          "@type": "type.googleapis.com/google.protobuf.Duration",
-                          "value": "1.212s"
-                        }
-      parameters:
-        - name: subspace_id
-          description: subspace to query the blocks for.
-          in: query
-          required: false
-          type: string
-          format: uint64
-        - name: blocker
-          description: optional address of the blocker to query the blocks for.
-          in: query
-          required: false
-          type: string
-        - name: blocked
-          description: >-
-            optional address of the blocked user to query the block for (used
-            only if
-
-            the blocker is provided).
-          in: query
-          required: false
-          type: string
-        - name: pagination.key
-          description: |-
-            key is a value returned in PageResponse.next_key to begin
-            querying the next page most efficiently. Only one of offset or key
-            should be set.
-          in: query
-          required: false
-          type: string
-          format: byte
-        - name: pagination.offset
-          description: >-
-            offset is a numeric offset that can be used when key is unavailable.
-
-            It is less efficient than using key. Only one of offset or key
-            should
-
-            be set.
-          in: query
-          required: false
-          type: string
-          format: uint64
-        - name: pagination.limit
-          description: >-
-            limit is the total number of results to be returned in the result
-            page.
-
-            If left empty it will default to a value to be set by each app.
-          in: query
-          required: false
-          type: string
-          format: uint64
-        - name: pagination.count_total
-          description: >-
-            count_total is set to true  to indicate that the result set should
-            include
-
-            a count of the total number of items available for pagination in
-            UIs.
-
-            count_total is only respected when offset is used. It is ignored
-            when key
-
-            is set.
-          in: query
-          required: false
-          type: boolean
-          format: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
-          in: query
-          required: false
-          type: boolean
-          format: boolean
       tags:
         - Query
-  /desmos/relationships/v1/relationships:
+  '/desmos/supply/v1/circulating/{denom}':
     get:
       summary: >-
-        Relationships queries all relationships present inside a specific
-        subspace
-      operationId: Relationships
+        Circulating queries the amount of tokens circulating in the market of
+        the
+
+        given denom
+      operationId: Circulating
       responses:
         '200':
           description: A successful response.
           schema:
             type: object
             properties:
-              relationships:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    creator:
-                      type: string
-                      title: Creator represents the creator of the relationship
-                    counterparty:
-                      type: string
-                      title: >-
-                        Counterparty represents the other user involved in the
-                        relationship
-                    subspace_id:
-                      type: string
-                      format: uint64
-                      title: >-
-                        SubspaceID represents the id of the subspace for which
-                        the relationship is
+              circulating_supply:
+                type: string
+            title: >-
+              QueryCirculatingResponse is the response type for the
+              Query/Circulating RPC
 
-                        valid
-                  description: >-
-                    Relationship is the struct of a relationship.
-
-                    It represent the concept of "follow" of traditional social
-                    networks.
-              pagination:
-                type: object
-                properties:
-                  next_key:
-                    type: string
-                    format: byte
-                    title: |-
-                      next_key is the key to be passed to PageRequest.key to
-                      query the next page most efficiently
-                  total:
-                    type: string
-                    format: uint64
-                    title: >-
-                      total is total number of results available if
-                      PageRequest.count_total
-
-                      was set, its value is undefined otherwise
-                description: >-
-                  PageResponse is to be embedded in gRPC response messages where
-                  the
-
-                  corresponding request message has used PageRequest.
-
-                   message SomeResponse {
-                           repeated Bar results = 1;
-                           PageResponse page = 2;
-                   }
-            description: |-
-              QueryRelationshipsResponse is the response type for the
-              Query/Relationships RPC method.
+              method
         default:
           description: An unexpected error response
           schema:
@@ -4652,84 +5012,243 @@ paths:
                           "value": "1.212s"
                         }
       parameters:
-        - name: subspace_id
-          description: subspace to query the relationships for.
+        - name: denom
+          description: coin denom to query the circulating supply for
+          in: path
+          required: true
+          type: string
+        - name: divider_exponent
+          description: >-
+            divider_exponent is a factor used to power the divider used to
+            convert the
+
+            supply to the desired representation.
           in: query
           required: false
           type: string
           format: uint64
-        - name: user
-          description: optional address of the user for which to query the relationships.
-          in: query
-          required: false
+      tags:
+        - Query
+  '/desmos/supply/v1/total/{denom}':
+    get:
+      summary: Total queries the total supply of the given denom
+      operationId: Total
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              total_supply:
+                type: string
+            title: >-
+              QueryTotalResponse is the response type for the Query/Total RPC
+              method
+        default:
+          description: An unexpected error response
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := ptypes.MarshalAny(foo)
+                         ...
+                         foo := &pb.Foo{}
+                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: denom
+          description: coin denom to query the circulating supply for
+          in: path
+          required: true
           type: string
-        - name: counterparty
+        - name: divider_exponent
           description: >-
-            optional address of the counterparty of the relationships (used only
-            if the
+            divider_exponent is a factor used to power the divider used to
+            convert the
 
-            user is provided).
-          in: query
-          required: false
-          type: string
-        - name: pagination.key
-          description: |-
-            key is a value returned in PageResponse.next_key to begin
-            querying the next page most efficiently. Only one of offset or key
-            should be set.
-          in: query
-          required: false
-          type: string
-          format: byte
-        - name: pagination.offset
-          description: >-
-            offset is a numeric offset that can be used when key is unavailable.
-
-            It is less efficient than using key. Only one of offset or key
-            should
-
-            be set.
+            supply to the desired representation.
           in: query
           required: false
           type: string
           format: uint64
-        - name: pagination.limit
-          description: >-
-            limit is the total number of results to be returned in the result
-            page.
-
-            If left empty it will default to a value to be set by each app.
-          in: query
-          required: false
-          type: string
-          format: uint64
-        - name: pagination.count_total
-          description: >-
-            count_total is set to true  to indicate that the result set should
-            include
-
-            a count of the total number of items available for pagination in
-            UIs.
-
-            count_total is only respected when offset is used. It is ignored
-            when key
-
-            is set.
-          in: query
-          required: false
-          type: boolean
-          format: boolean
-        - name: pagination.reverse
-          description: >-
-            reverse is set to true if results are to be returned in the
-            descending order.
-
-
-            Since: cosmos-sdk 0.43
-          in: query
-          required: false
-          type: boolean
-          format: boolean
       tags:
         - Query
 definitions:
@@ -7764,6 +8283,166 @@ definitions:
                   "@type": "type.googleapis.com/google.protobuf.Duration",
                   "value": "1.212s"
                 }
+  desmos.relationships.v1.QueryBlocksResponse:
+    type: object
+    properties:
+      blocks:
+        type: array
+        items:
+          type: object
+          properties:
+            blocker:
+              type: string
+              title: Blocker represents the address of the user blocking another one
+            blocked:
+              type: string
+              title: Blocked represents the address of the blocked user
+            reason:
+              type: string
+              description: >-
+                Reason represents the optional reason the user has been blocked
+                for.
+            subspace_id:
+              type: string
+              format: uint64
+              title: >-
+                SubspaceID represents the ID of the subspace inside which the
+                user should
+
+                be blocked
+          description: >-
+            UserBlock represents the fact that the Blocker has blocked the given
+            Blocked
+
+            user.
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            title: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+    description: |-
+      QueryBlocksResponse is the response type for the Query/Blocks RPC
+      method.
+  desmos.relationships.v1.QueryRelationshipsResponse:
+    type: object
+    properties:
+      relationships:
+        type: array
+        items:
+          type: object
+          properties:
+            creator:
+              type: string
+              title: Creator represents the creator of the relationship
+            counterparty:
+              type: string
+              title: >-
+                Counterparty represents the other user involved in the
+                relationship
+            subspace_id:
+              type: string
+              format: uint64
+              title: >-
+                SubspaceID represents the id of the subspace for which the
+                relationship is
+
+                valid
+          description: |-
+            Relationship is the struct of a relationship.
+            It represent the concept of "follow" of traditional social networks.
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            title: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+    description: |-
+      QueryRelationshipsResponse is the response type for the
+      Query/Relationships RPC method.
+  desmos.relationships.v1.Relationship:
+    type: object
+    properties:
+      creator:
+        type: string
+        title: Creator represents the creator of the relationship
+      counterparty:
+        type: string
+        title: Counterparty represents the other user involved in the relationship
+      subspace_id:
+        type: string
+        format: uint64
+        title: >-
+          SubspaceID represents the id of the subspace for which the
+          relationship is
+
+          valid
+    description: |-
+      Relationship is the struct of a relationship.
+      It represent the concept of "follow" of traditional social networks.
+  desmos.relationships.v1.UserBlock:
+    type: object
+    properties:
+      blocker:
+        type: string
+        title: Blocker represents the address of the user blocking another one
+      blocked:
+        type: string
+        title: Blocked represents the address of the blocked user
+      reason:
+        type: string
+        description: Reason represents the optional reason the user has been blocked for.
+      subspace_id:
+        type: string
+        format: uint64
+        title: >-
+          SubspaceID represents the ID of the subspace inside which the user
+          should
+
+          be blocked
+    description: >-
+      UserBlock represents the fact that the Blocker has blocked the given
+      Blocked
+
+      user.
   desmos.subspaces.v1.PermissionDetail:
     type: object
     properties:
@@ -8126,163 +8805,113 @@ definitions:
         format: int64
         title: Permissions that will be granted to all the users part of this group
     title: UserGroup represents a group of users
-  desmos.relationships.v1.QueryBlocksResponse:
+  desmos.fees.v1.MinFee:
     type: object
     properties:
-      blocks:
+      message_type:
+        type: string
+      amount:
         type: array
         items:
           type: object
           properties:
-            blocker:
+            denom:
               type: string
-              title: Blocker represents the address of the user blocking another one
-            blocked:
+            amount:
               type: string
-              title: Blocked represents the address of the blocked user
-            reason:
-              type: string
-              description: >-
-                Reason represents the optional reason the user has been blocked
-                for.
-            subspace_id:
-              type: string
-              format: uint64
-              title: >-
-                SubspaceID represents the ID of the subspace inside which the
-                user should
-
-                be blocked
-          description: >-
-            UserBlock represents the fact that the Blocker has blocked the given
-            Blocked
-
-            user.
-      pagination:
-        type: object
-        properties:
-          next_key:
-            type: string
-            format: byte
-            title: |-
-              next_key is the key to be passed to PageRequest.key to
-              query the next page most efficiently
-          total:
-            type: string
-            format: uint64
-            title: >-
-              total is total number of results available if
-              PageRequest.count_total
-
-              was set, its value is undefined otherwise
-        description: |-
-          PageResponse is to be embedded in gRPC response messages where the
-          corresponding request message has used PageRequest.
-
-           message SomeResponse {
-                   repeated Bar results = 1;
-                   PageResponse page = 2;
-           }
-    description: |-
-      QueryBlocksResponse is the response type for the Query/Blocks RPC
-      method.
-  desmos.relationships.v1.QueryRelationshipsResponse:
-    type: object
-    properties:
-      relationships:
-        type: array
-        items:
-          type: object
-          properties:
-            creator:
-              type: string
-              title: Creator represents the creator of the relationship
-            counterparty:
-              type: string
-              title: >-
-                Counterparty represents the other user involved in the
-                relationship
-            subspace_id:
-              type: string
-              format: uint64
-              title: >-
-                SubspaceID represents the id of the subspace for which the
-                relationship is
-
-                valid
           description: |-
-            Relationship is the struct of a relationship.
-            It represent the concept of "follow" of traditional social networks.
-      pagination:
+            Coin defines a token with a denomination and an amount.
+
+            NOTE: The amount field is an Int which implements the custom method
+            signatures required by gogoproto.
+    title: >-
+      MinFee contains the minimum amount of coins that should be paid as a fee
+      for
+
+      each message of the specific type sent
+  desmos.fees.v1.Params:
+    type: object
+    properties:
+      min_fees:
+        type: array
+        items:
+          type: object
+          properties:
+            message_type:
+              type: string
+            amount:
+              type: array
+              items:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                  amount:
+                    type: string
+                description: >-
+                  Coin defines a token with a denomination and an amount.
+
+
+                  NOTE: The amount field is an Int which implements the custom
+                  method
+
+                  signatures required by gogoproto.
+          title: >-
+            MinFee contains the minimum amount of coins that should be paid as a
+            fee for
+
+            each message of the specific type sent
+    title: Params contains the parameters for the fees module
+  desmos.fees.v1.QueryParamsResponse:
+    type: object
+    properties:
+      params:
         type: object
         properties:
-          next_key:
-            type: string
-            format: byte
-            title: |-
-              next_key is the key to be passed to PageRequest.key to
-              query the next page most efficiently
-          total:
-            type: string
-            format: uint64
-            title: >-
-              total is total number of results available if
-              PageRequest.count_total
+          min_fees:
+            type: array
+            items:
+              type: object
+              properties:
+                message_type:
+                  type: string
+                amount:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      denom:
+                        type: string
+                      amount:
+                        type: string
+                    description: >-
+                      Coin defines a token with a denomination and an amount.
 
-              was set, its value is undefined otherwise
-        description: |-
-          PageResponse is to be embedded in gRPC response messages where the
-          corresponding request message has used PageRequest.
 
-           message SomeResponse {
-                   repeated Bar results = 1;
-                   PageResponse page = 2;
-           }
-    description: |-
-      QueryRelationshipsResponse is the response type for the
-      Query/Relationships RPC method.
-  desmos.relationships.v1.Relationship:
+                      NOTE: The amount field is an Int which implements the
+                      custom method
+
+                      signatures required by gogoproto.
+              title: >-
+                MinFee contains the minimum amount of coins that should be paid
+                as a fee for
+
+                each message of the specific type sent
+        title: Params contains the parameters for the fees module
+    title: QueryParamsResponse is the response type for the Query/Params RPC
+  desmos.supply.v1.QueryCirculatingResponse:
     type: object
     properties:
-      creator:
+      circulating_supply:
         type: string
-        title: Creator represents the creator of the relationship
-      counterparty:
-        type: string
-        title: Counterparty represents the other user involved in the relationship
-      subspace_id:
-        type: string
-        format: uint64
-        title: >-
-          SubspaceID represents the id of the subspace for which the
-          relationship is
+    title: >-
+      QueryCirculatingResponse is the response type for the Query/Circulating
+      RPC
 
-          valid
-    description: |-
-      Relationship is the struct of a relationship.
-      It represent the concept of "follow" of traditional social networks.
-  desmos.relationships.v1.UserBlock:
+      method
+  desmos.supply.v1.QueryTotalResponse:
     type: object
     properties:
-      blocker:
+      total_supply:
         type: string
-        title: Blocker represents the address of the user blocking another one
-      blocked:
-        type: string
-        title: Blocked represents the address of the blocked user
-      reason:
-        type: string
-        description: Reason represents the optional reason the user has been blocked for.
-      subspace_id:
-        type: string
-        format: uint64
-        title: >-
-          SubspaceID represents the ID of the subspace inside which the user
-          should
-
-          be blocked
-    description: >-
-      UserBlock represents the fact that the Blocker has blocked the given
-      Blocked
-
-      user.
+    title: QueryTotalResponse is the response type for the Query/Total RPC method


### PR DESCRIPTION
## Description

This PR updates the Swagger config and UI to include `x/fees` and `x/supply` queries. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)