### PR TITLE
fix: fix external hooks to not overwrite data

### DIFF
--- a/x/posts/keeper/external_hooks.go
+++ b/x/posts/keeper/external_hooks.go
@@ -21,7 +21,9 @@ func (k Keeper) Hooks() Hooks { return Hooks{k} }
 // AfterSubspaceSaved implements subspacestypes.Hooks
 func (h Hooks) AfterSubspaceSaved(ctx sdk.Context, subspaceID uint64) {
 	// Create the initial post it
-	h.k.SetNextPostID(ctx, subspaceID, 1)
+	if !h.k.HasNextPostID(ctx, subspaceID) {
+		h.k.SetNextPostID(ctx, subspaceID, 1)
+	}
 }
 
 // AfterSubspaceDeleted implements subspacestypes.Hooks

--- a/x/reports/keeper/external_hooks.go
+++ b/x/reports/keeper/external_hooks.go
@@ -24,8 +24,12 @@ func (k Keeper) Hooks() Hooks { return Hooks{k} }
 // AfterSubspaceSaved implements subspacestypes.Hooks
 func (h Hooks) AfterSubspaceSaved(ctx sdk.Context, subspaceID uint64) {
 	// Create the initial reason and report id
-	h.k.SetNextReasonID(ctx, subspaceID, 1)
-	h.k.SetNextReportID(ctx, subspaceID, 1)
+	if !h.k.HasNextReasonID(ctx, subspaceID) {
+		h.k.SetNextReasonID(ctx, subspaceID, 1)
+	}
+	if !h.k.HasNextReportID(ctx, subspaceID) {
+		h.k.SetNextReportID(ctx, subspaceID, 1)
+	}
 }
 
 // AfterSubspaceDeleted implements subspacestypes.Hooks

--- a/x/reports/keeper/external_hooks_test.go
+++ b/x/reports/keeper/external_hooks_test.go
@@ -39,6 +39,40 @@ func (suite *KeeperTestsuite) TestKeeper_AfterSubspaceSaved() {
 				suite.Require().Equal(uint64(1), storedReportID)
 			},
 		},
+		{
+			name: "reason and report ids are not overwritten",
+			store: func(ctx sdk.Context) {
+				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
+					1,
+					"Test subspace",
+					"This is a test subspace",
+					"cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm",
+					"cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm",
+					"cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm",
+					time.Date(2020, 1, 2, 12, 00, 00, 000, time.UTC),
+				))
+				suite.k.SetNextReportID(ctx, 1, 2)
+				suite.k.SetNextReasonID(ctx, 1, 2)
+			},
+			subspace: subspacestypes.NewSubspace(
+				1,
+				"Test subspace",
+				"This is a test subspace",
+				"cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm",
+				"cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm",
+				"cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm",
+				time.Date(2020, 1, 2, 12, 00, 00, 000, time.UTC),
+			),
+			check: func(ctx sdk.Context) {
+				storedReasonID, err := suite.k.GetNextReasonID(ctx, 1)
+				suite.Require().NoError(err)
+				suite.Require().Equal(uint32(2), storedReasonID)
+
+				storedReportID, err := suite.k.GetNextReportID(ctx, 1)
+				suite.Require().NoError(err)
+				suite.Require().Equal(uint64(2), storedReportID)
+			},
+		},
 	}
 
 	// Set the hooks


### PR DESCRIPTION
## Description

This PR fixes the `x/posts` and `x/reports` external hooks to not overwrite the data. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)