### PR TITLE
feat: require a profile for MsgCreatePost, MsgAnswerPoll and MsgCreateReport

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -495,6 +495,7 @@ func NewDesmosApp(
 		app.appCodec,
 		keys[poststypes.StoreKey],
 		app.GetSubspace(poststypes.ModuleName),
+		app.ProfileKeeper,
 		&subspacesKeeper,
 		app.RelationshipsKeeper,
 	)

--- a/app/app.go
+++ b/app/app.go
@@ -505,6 +505,7 @@ func NewDesmosApp(
 		app.appCodec,
 		keys[reportstypes.StoreKey],
 		app.GetSubspace(reportstypes.ModuleName),
+		app.ProfileKeeper,
 		&subspacesKeeper,
 		app.RelationshipsKeeper,
 		&postsKeeper,

--- a/x/posts/keeper/alias_functions.go
+++ b/x/posts/keeper/alias_functions.go
@@ -12,6 +12,11 @@ import (
 	"github.com/desmos-labs/desmos/v3/x/posts/types"
 )
 
+// HasProfile returns true iff the given user has a profile, or an error if something is wrong.
+func (k Keeper) HasProfile(ctx sdk.Context, user string) bool {
+	return k.ak.HasProfile(ctx, user)
+}
+
 // HasSubspace checks whether the given subspace exists or not
 func (k Keeper) HasSubspace(ctx sdk.Context, subspaceID uint64) bool {
 	return k.sk.HasSubspace(ctx, subspaceID)

--- a/x/posts/keeper/keeper.go
+++ b/x/posts/keeper/keeper.go
@@ -16,12 +16,16 @@ type Keeper struct {
 	paramsSubspace paramstypes.Subspace
 	hooks          types.PostsHooks
 
+	ak types.ProfilesKeeper
 	sk types.SubspacesKeeper
 	rk types.RelationshipsKeeper
 }
 
 // NewKeeper creates a new instance of the Posts Keeper.
-func NewKeeper(cdc codec.BinaryCodec, storeKey sdk.StoreKey, paramsSubspace paramstypes.Subspace, sk types.SubspacesKeeper, rk types.RelationshipsKeeper) Keeper {
+func NewKeeper(
+	cdc codec.BinaryCodec, storeKey sdk.StoreKey, paramsSubspace paramstypes.Subspace,
+	ak types.ProfilesKeeper, sk types.SubspacesKeeper, rk types.RelationshipsKeeper,
+) Keeper {
 	if !paramsSubspace.HasKeyTable() {
 		paramsSubspace = paramsSubspace.WithKeyTable(types.ParamKeyTable())
 	}
@@ -31,6 +35,7 @@ func NewKeeper(cdc codec.BinaryCodec, storeKey sdk.StoreKey, paramsSubspace para
 		cdc:            cdc,
 		paramsSubspace: paramsSubspace,
 
+		ak: ak,
 		sk: sk,
 		rk: rk,
 	}

--- a/x/posts/keeper/msg_server_test.go
+++ b/x/posts/keeper/msg_server_test.go
@@ -3,6 +3,8 @@ package keeper_test
 import (
 	"time"
 
+	"github.com/desmos-labs/desmos/v3/testutil"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/desmos-labs/desmos/v3/x/posts/keeper"
@@ -22,7 +24,27 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 		check       func(ctx sdk.Context)
 	}{
 		{
+			name: "user without profile returns error",
+			msg: types.NewMsgCreatePost(
+				1,
+				1,
+				"External ID",
+				"This is a text",
+				1,
+				types.REPLY_SETTING_EVERYONE,
+				nil,
+				nil,
+				nil,
+				"cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd",
+			),
+			shouldErr: true,
+		},
+		{
 			name: "non existing subspace returns error",
+			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+			},
 			msg: types.NewMsgCreatePost(
 				1,
 				1,
@@ -52,6 +74,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 				"cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd",
 			),
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -67,6 +92,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 		{
 			name: "user without permission returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -94,6 +122,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 		{
 			name: "invalid conversation id returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -130,6 +161,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 		{
 			name: "invalid reference returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -170,6 +204,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 		{
 			name: "initial post id not set returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -207,6 +244,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 				return ctx.WithBlockTime(time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC))
 			},
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -249,6 +289,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 				return ctx.WithBlockTime(time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC))
 			},
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -292,6 +335,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreatePost() {
 				return ctx.WithBlockTime(time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC))
 			},
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1586,7 +1632,22 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		check     func(ctx sdk.Context)
 	}{
 		{
+			name: "user without profile returns error",
+			msg: types.NewMsgAnswerPoll(
+				1,
+				1,
+				1,
+				[]uint32{1, 2, 3},
+				"cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd",
+			),
+			shouldErr: true,
+		},
+		{
 			name: "not found subspace returns error",
+			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+			},
 			msg: types.NewMsgAnswerPoll(
 				1,
 				1,
@@ -1599,6 +1660,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "user without permission returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1621,6 +1685,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "not found post returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1650,6 +1717,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "not found poll returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1694,6 +1764,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "already answered poll returns error if no answer edits are allowed",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1763,6 +1836,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "multiple answers return error if they are not allowed",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1824,6 +1900,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "invalid answer indexes return error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1885,6 +1964,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "editing an answer works correctly",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",
@@ -1980,6 +2062,9 @@ func (suite *KeeperTestsuite) TestMsgServer_AnswerPoll() {
 		{
 			name: "new answer is stored correctly",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test",

--- a/x/posts/simulation/operations_polls.go
+++ b/x/posts/simulation/operations_polls.go
@@ -81,6 +81,12 @@ func randomAnswerPollFields(
 	}
 	user = *acc
 
+	if !k.HasProfile(ctx, user.Address.String()) {
+		// Skip because the user does not have a profile
+		skip = true
+		return
+	}
+
 	// Get some answers
 	answersIndexes := RandomAnswersIndexes(r, poll.Content.GetCachedValue().(*types.Poll))
 	userAnswer := types.NewUserAnswer(poll.SubspaceID, poll.PostID, poll.ID, answersIndexes, user.Address.String())

--- a/x/posts/simulation/operations_posts.go
+++ b/x/posts/simulation/operations_posts.go
@@ -86,6 +86,12 @@ func randomPostCreateFields(
 	}
 	author = *acc
 
+	if !k.HasProfile(ctx, author.Address.String()) {
+		// Skip because the author does not have a profile
+		skip = true
+		return
+	}
+
 	postID, err := k.GetNextPostID(ctx, section.SubspaceID)
 	if err != nil {
 		panic(err)

--- a/x/posts/types/expected_keepers.go
+++ b/x/posts/types/expected_keepers.go
@@ -6,6 +6,12 @@ import (
 	subspacestypes "github.com/desmos-labs/desmos/v3/x/subspaces/types"
 )
 
+// ProfilesKeeper represents a keeper that deals with profiles
+type ProfilesKeeper interface {
+	// HasProfile returns true iff the given user has a profile
+	HasProfile(ctx sdk.Context, user string) bool
+}
+
 // SubspacesKeeper represents a keeper that deals with subspaces
 type SubspacesKeeper interface {
 	// HasSubspace tells whether the subspace with the given id exists or not

--- a/x/reports/keeper/alias_functions.go
+++ b/x/reports/keeper/alias_functions.go
@@ -12,6 +12,11 @@ import (
 	subspacestypes "github.com/desmos-labs/desmos/v3/x/subspaces/types"
 )
 
+// HasProfile returns true iff the given user has a profile, or an error if something is wrong.
+func (k Keeper) HasProfile(ctx sdk.Context, user string) bool {
+	return k.ak.HasProfile(ctx, user)
+}
+
 // HasSubspace tells whether the subspace with the given id exists or not
 func (k Keeper) HasSubspace(ctx sdk.Context, subspaceID uint64) bool {
 	return k.sk.HasSubspace(ctx, subspaceID)

--- a/x/reports/keeper/common_test.go
+++ b/x/reports/keeper/common_test.go
@@ -87,6 +87,7 @@ func (suite *KeeperTestsuite) SetupTest() {
 		suite.cdc,
 		suite.storeKey,
 		paramsKeeper.Subspace(types.DefaultParamsSpace),
+		suite.ak,
 		suite.sk,
 		suite.rk,
 		suite.pk,

--- a/x/reports/keeper/keeper.go
+++ b/x/reports/keeper/keeper.go
@@ -15,6 +15,7 @@ type Keeper struct {
 	paramsSubspace paramstypes.Subspace
 	hooks          types.ReportsHooks
 
+	ak types.ProfilesKeeper
 	sk types.SubspacesKeeper
 	rk types.RelationshipsKeeper
 	pk types.PostsKeeper
@@ -23,7 +24,7 @@ type Keeper struct {
 // NewKeeper creates a new instance of the Posts Keeper.
 func NewKeeper(
 	cdc codec.BinaryCodec, storeKey sdk.StoreKey, paramsSubspace paramstypes.Subspace,
-	sk types.SubspacesKeeper, rk types.RelationshipsKeeper, pk types.PostsKeeper,
+	ak types.ProfilesKeeper, sk types.SubspacesKeeper, rk types.RelationshipsKeeper, pk types.PostsKeeper,
 ) Keeper {
 	if !paramsSubspace.HasKeyTable() {
 		paramsSubspace = paramsSubspace.WithKeyTable(types.ParamKeyTable())
@@ -34,6 +35,7 @@ func NewKeeper(
 		cdc:            cdc,
 		paramsSubspace: paramsSubspace,
 
+		ak: ak,
 		sk: sk,
 		rk: rk,
 		pk: pk,

--- a/x/reports/keeper/msg_server.go
+++ b/x/reports/keeper/msg_server.go
@@ -27,6 +27,11 @@ var _ types.MsgServer = &msgServer{}
 func (k msgServer) CreateReport(goCtx context.Context, msg *types.MsgCreateReport) (*types.MsgCreateReportResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	// Check if the reporter has a profile
+	if !k.HasProfile(ctx, msg.Reporter) {
+		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "you cannot create a report without having a profile")
+	}
+
 	// Check if the subspace exists
 	if !k.HasSubspace(ctx, msg.SubspaceID) {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "subspace with id %d not found", msg.SubspaceID)

--- a/x/reports/keeper/msg_server_test.go
+++ b/x/reports/keeper/msg_server_test.go
@@ -3,6 +3,8 @@ package keeper_test
 import (
 	"time"
 
+	"github.com/desmos-labs/desmos/v3/testutil"
+
 	poststypes "github.com/desmos-labs/desmos/v3/x/posts/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -24,7 +26,22 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateReport() {
 		check       func(ctx sdk.Context)
 	}{
 		{
+			name: "user without profile returns error",
+			msg: types.NewMsgCreateReport(
+				1,
+				[]uint32{1},
+				"This content is spam!",
+				types.NewUserTarget("cosmos1ggzk8tnte9lmzgpvyzzdtmwmn6rjlct4spmjjd"),
+				"cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh",
+			),
+			shouldErr: true,
+		},
+		{
 			name: "non existing subspace returns error",
+			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"))
+				suite.Require().NoError(err)
+			},
 			msg: types.NewMsgCreateReport(
 				1,
 				[]uint32{1},
@@ -37,6 +54,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateReport() {
 		{
 			name: "non existing reason returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test subspace",
@@ -60,6 +80,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateReport() {
 		{
 			name: "no permission returns error",
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test subspace",
@@ -93,6 +116,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateReport() {
 				return ctx.WithBlockTime(time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC))
 			},
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test subspace",
@@ -133,6 +159,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateReport() {
 				return ctx.WithBlockTime(time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC))
 			},
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test subspace",
@@ -183,6 +212,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateReport() {
 				return ctx.WithBlockTime(time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC))
 			},
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test subspace",
@@ -253,6 +285,9 @@ func (suite *KeeperTestsuite) TestMsgServer_CreateReport() {
 				return ctx.WithBlockTime(time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC))
 			},
 			store: func(ctx sdk.Context) {
+				err := suite.ak.SaveProfile(ctx, testutil.ProfileFromAddr("cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"))
+				suite.Require().NoError(err)
+
 				suite.sk.SaveSubspace(ctx, subspacestypes.NewSubspace(
 					1,
 					"Test subspace",

--- a/x/reports/simulation/operations_reports.go
+++ b/x/reports/simulation/operations_reports.go
@@ -120,6 +120,12 @@ func randomCreateReportFields(
 	}
 	creator = *acc
 
+	if !k.HasProfile(ctx, creator.Address.String()) {
+		// Skip because the creator does not have a profile
+		skip = true
+		return
+	}
+
 	// Get the report target
 	report = types.NewReport(
 		subspaceID,

--- a/x/reports/types/expected_keepers.go
+++ b/x/reports/types/expected_keepers.go
@@ -8,6 +8,12 @@ import (
 	subspacestypes "github.com/desmos-labs/desmos/v3/x/subspaces/types"
 )
 
+// ProfilesKeeper represents a keeper that deals with profiles
+type ProfilesKeeper interface {
+	// HasProfile returns true iff the given user has a profile
+	HasProfile(ctx sdk.Context, user string) bool
+}
+
 // SubspacesKeeper represents a keeper that deals with subspaces
 type SubspacesKeeper interface {
 	// HasSubspace tells whether the subspace with the given id exists or not


### PR DESCRIPTION
## Description
This PR adds the requirement to have a profile when sending a `MsgCreatePost`, `MsgAnswerPoll` and `MsgCreateReport`. 

This is done due to the fact that those features should be used only by users of the protocol, and as a (very naive) spam prevention system. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)