### PR TITLE
chore: improve the x/reports CLI commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.4.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.2
 	github.com/tendermint/tendermint v0.34.19
 	github.com/tendermint/tm-db v0.6.7
@@ -109,7 +110,6 @@ require (
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.11.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect

--- a/x/reports/client/cli/cli_test.go
+++ b/x/reports/client/cli/cli_test.go
@@ -160,7 +160,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-func (s *IntegrationTestSuite) TestCmdQueryUserReports() {
+func (s *IntegrationTestSuite) TestCmdQueryReports() {
 	val := s.network.Validators[0]
 	testCases := []struct {
 		name        string
@@ -169,9 +169,10 @@ func (s *IntegrationTestSuite) TestCmdQueryUserReports() {
 		expResponse types.QueryReportsResponse
 	}{
 		{
-			name: "reports are returned correctly",
+			name: "user reports are returned correctly",
 			args: []string{
-				"1", "cosmos1pjffdtweghpyxru9alssyqtdkq8mn6sepgstgm",
+				"1",
+				fmt.Sprintf("--%s=%s", cli.FlagUser, "cosmos1pjffdtweghpyxru9alssyqtdkq8mn6sepgstgm"),
 				fmt.Sprintf("--%s=%s", cli.FlagReporter, "cosmos1zkmf50jq4lzvhvp5ekl0sdf2p4g3v9v8edt24z"),
 				fmt.Sprintf("--%s=%d", flags.FlagLimit, 1),
 				fmt.Sprintf("--%s=%d", flags.FlagPage, 1),
@@ -192,40 +193,11 @@ func (s *IntegrationTestSuite) TestCmdQueryUserReports() {
 				},
 			},
 		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		s.Run(tc.name, func() {
-			cmd := cli.GetCmdQueryUserReports()
-			clientCtx := val.ClientCtx
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-
-			if tc.shouldErr {
-				s.Require().Error(err)
-			} else {
-				s.Require().NoError(err)
-
-				var response types.QueryReportsResponse
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
-				s.Require().Equal(response.Reports, tc.expResponse.Reports)
-			}
-		})
-	}
-}
-
-func (s *IntegrationTestSuite) TestCmdQueryPostReports() {
-	val := s.network.Validators[0]
-	testCases := []struct {
-		name        string
-		args        []string
-		shouldErr   bool
-		expResponse types.QueryReportsResponse
-	}{
 		{
-			name: "reports are returned correctly",
+			name: "posts reports are returned properly",
 			args: []string{
-				"1", "1",
+				"1",
+				fmt.Sprintf("--%s=%d", cli.FlagPostID, 1),
 				fmt.Sprintf("--%s=%s", cli.FlagReporter, "cosmos1zkmf50jq4lzvhvp5ekl0sdf2p4g3v9v8edt24z"),
 				fmt.Sprintf("--%s=%d", flags.FlagLimit, 1),
 				fmt.Sprintf("--%s=%d", flags.FlagPage, 1),
@@ -246,36 +218,6 @@ func (s *IntegrationTestSuite) TestCmdQueryPostReports() {
 				},
 			},
 		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		s.Run(tc.name, func() {
-			cmd := cli.GetCmdQueryPostReports()
-			clientCtx := val.ClientCtx
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-
-			if tc.shouldErr {
-				s.Require().Error(err)
-			} else {
-				s.Require().NoError(err)
-
-				var response types.QueryReportsResponse
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
-				s.Require().Equal(response.Reports, tc.expResponse.Reports)
-			}
-		})
-	}
-}
-
-func (s *IntegrationTestSuite) TestCmdQueryReports() {
-	val := s.network.Validators[0]
-	testCases := []struct {
-		name        string
-		args        []string
-		shouldErr   bool
-		expResponse types.QueryReportsResponse
-	}{
 		{
 			name: "reports are returned correctly",
 			args: []string{
@@ -413,7 +355,7 @@ func (s *IntegrationTestSuite) TestCmdQueryParams() {
 	}
 }
 
-func (s *IntegrationTestSuite) TestCmdReportUser() {
+func (s *IntegrationTestSuite) TestCmdCreateReport() {
 	val := s.network.Validators[0]
 	testCases := []struct {
 		name      string
@@ -429,23 +371,43 @@ func (s *IntegrationTestSuite) TestCmdReportUser() {
 			shouldErr: true,
 		},
 		{
-			name: "invalid user address returns error",
-			args: []string{
-				"1", "invalid-address", "1",
-			},
-			shouldErr: true,
-		},
-		{
 			name: "invalid reason id returns error",
 			args: []string{
-				"1", "cosmos1wprgptc8ktt0eemrn2znpxv8crdxm8tdpkdr7w", "0",
+				"1", "0",
 			},
 			shouldErr: true,
 		},
 		{
-			name: "valid data returns no error",
+			name: "missing flags return error",
 			args: []string{
-				"1", "cosmos1wprgptc8ktt0eemrn2znpxv8crdxm8tdpkdr7w", "1,2,3",
+				"1", "1",
+				fmt.Sprintf("--%s=%s", cli.FlagMessage, "This is a new report"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+			},
+			shouldErr: true,
+		},
+		{
+			name: "valid user address returns no error",
+			args: []string{
+				"1", "1,2,3",
+				fmt.Sprintf("--%s=%s", cli.FlagUser, "cosmos1wprgptc8ktt0eemrn2znpxv8crdxm8tdpkdr7w"),
+				fmt.Sprintf("--%s=%s", cli.FlagMessage, "This is a new report"),
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+			},
+			shouldErr: false,
+			respType:  &sdk.TxResponse{},
+		},
+		{
+			name: "valid post id returns no error",
+			args: []string{
+				"1", "1,2,3",
+				fmt.Sprintf("--%s=%d", cli.FlagPostID, 1),
 				fmt.Sprintf("--%s=%s", cli.FlagMessage, "This is a new report"),
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
@@ -460,68 +422,7 @@ func (s *IntegrationTestSuite) TestCmdReportUser() {
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-			cmd := cli.GetCmdReportUser()
-			clientCtx := val.ClientCtx
-
-			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
-			if tc.shouldErr {
-				s.Require().Error(err)
-			} else {
-				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
-			}
-		})
-	}
-}
-
-func (s *IntegrationTestSuite) TestCmdReportPost() {
-	val := s.network.Validators[0]
-	testCases := []struct {
-		name      string
-		args      []string
-		shouldErr bool
-		respType  proto.Message
-	}{
-		{
-			name: "invalid subspace id returns error",
-			args: []string{
-				"", "1", "cosmos1wprgptc8ktt0eemrn2znpxv8crdxm8tdpkdr7w",
-			},
-			shouldErr: true,
-		},
-		{
-			name: "invalid post id returns error",
-			args: []string{
-				"1", "0", "1",
-			},
-			shouldErr: true,
-		},
-		{
-			name: "invalid reason id returns error",
-			args: []string{
-				"1", "1", "0",
-			},
-			shouldErr: true,
-		},
-		{
-			name: "valid data returns no error",
-			args: []string{
-				"1", "1", "1,2,3",
-				fmt.Sprintf("--%s=%s", cli.FlagMessage, "This is a new report"),
-				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
-				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
-				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
-			},
-			shouldErr: false,
-			respType:  &sdk.TxResponse{},
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		s.Run(tc.name, func() {
-			cmd := cli.GetCmdReportPost()
+			cmd := cli.GetCmdCreateReport()
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)

--- a/x/reports/client/cli/flags.go
+++ b/x/reports/client/cli/flags.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	"github.com/desmos-labs/desmos/v3/x/reports/types"
+)
+
+const (
+	FlagUser     = "user"
+	FlagPostID   = "post-id"
+	FlagReporter = "reporter"
+	FlagMessage  = "message"
+)
+
+// ReadReportTarget reads the given flags and returns the report target
+func ReadReportTarget(flagSet *pflag.FlagSet) (types.ReportTarget, error) {
+	userTarget, err := flagSet.GetString(FlagUser)
+	if err != nil {
+		return nil, err
+	}
+
+	postTarget, err := flagSet.GetUint64(FlagPostID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case userTarget != "" && postTarget != 0:
+		return nil, fmt.Errorf("only one of --%s or --%s must be used", FlagUser, FlagPostID)
+
+	case userTarget != "":
+		return types.NewUserTarget(userTarget), nil
+
+	case postTarget != 0:
+		return types.NewPostTarget(postTarget), nil
+	}
+
+	return nil, nil
+}

--- a/x/reports/client/cli/tx.go
+++ b/x/reports/client/cli/tx.go
@@ -152,7 +152,7 @@ func GetCmdDeleteReport() *cobra.Command {
 // NewReasonsTxCmd returns a new command to perform reasons transactions
 func NewReasonsTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                        "reactions",
+		Use:                        "reasons",
 		Short:                      "Reports reactions transaction subcommands",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,

--- a/x/reports/client/cli/tx.go
+++ b/x/reports/client/cli/tx.go
@@ -153,7 +153,7 @@ func GetCmdDeleteReport() *cobra.Command {
 func NewReasonsTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "reasons",
-		Short:                      "Reports reactions transaction subcommands",
+		Short:                      "Reports reasons transaction subcommands",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,


### PR DESCRIPTION
## Description

This PR improves the CLI commands organization for the `x/reports` module. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)