### PR TITLE
chore: improve x/reports validation test

### DIFF
--- a/x/reports/keeper/reports.go
+++ b/x/reports/keeper/reports.go
@@ -67,8 +67,14 @@ func (k Keeper) validatePostReportContent(ctx sdk.Context, report types.Report, 
 }
 
 // ValidateReport validates the given report's content
-func (k Keeper) ValidateReport(ctx sdk.Context, report types.Report) error {
-	var err error
+func (k Keeper) ValidateReport(ctx sdk.Context, report types.Report) (err error) {
+	// Validate the report
+	err = report.Validate()
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, err.Error())
+	}
+
+	// Validate the content
 	switch data := report.Target.GetCachedValue().(type) {
 	case *types.UserTarget:
 		err = k.validateUserReportContent(ctx, report, data)
@@ -76,11 +82,7 @@ func (k Keeper) ValidateReport(ctx sdk.Context, report types.Report) error {
 		err = k.validatePostReportContent(ctx, report, data)
 	}
 
-	if err != nil {
-		return err
-	}
-
-	return report.Validate()
+	return err
 }
 
 // getContentKey returns the store key used to save the report reference based on its content type

--- a/x/reports/keeper/reports_test.go
+++ b/x/reports/keeper/reports_test.go
@@ -149,6 +149,19 @@ func (suite *KeeperTestsuite) TestKeeper_ValidateReport() {
 		shouldErr bool
 	}{
 		{
+			name: "invalid report returns error",
+			report: types.NewReport(
+				0,
+				1,
+				[]uint32{1},
+				"This content is spam",
+				types.NewUserTarget("cosmos10s22qjua2n3law0ymstm3txm7764mfk2cjawq5"),
+				"cosmos1wprgptc8ktt0eemrn2znpxv8crdxm8tdpkdr7w",
+				time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
+			),
+			shouldErr: true,
+		},
+		{
 			name: "UserTarget - blocked reporter returns error",
 			store: func(ctx sdk.Context) {
 				suite.rk.SaveUserBlock(ctx, relationshipstypes.NewUserBlock(


### PR DESCRIPTION
## Description
This PR improves the reports validation tests

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)