### PR TITLE
fix: fixed poll answers query CLI command

### DIFF
--- a/x/posts/client/cli/cli_test.go
+++ b/x/posts/client/cli/cli_test.go
@@ -369,7 +369,7 @@ func (s *IntegrationTestSuite) TestCmdQueryPollAnswers() {
 		{
 			name: "answers are returned correctly if no user is specified",
 			args: []string{
-				"1", "1", "1", "",
+				"1", "1", "1",
 				fmt.Sprintf("--%s=%d", flags.FlagLimit, 2),
 				fmt.Sprintf("--%s=%d", flags.FlagPage, 1),
 				fmt.Sprintf("--%s=json", tmcli.OutputFlag),

--- a/x/posts/client/cli/query.go
+++ b/x/posts/client/cli/query.go
@@ -210,7 +210,12 @@ If a user address is provided, only the answer of that user will be returned (if
 				return err
 			}
 
-			res, err := queryClient.PollAnswers(context.Background(), types.NewQueryPollAnswersRequest(subspaceID, postID, pollID, args[3], pageReq))
+			var user string
+			if len(args) > 3 {
+				user = args[3]
+			}
+
+			res, err := queryClient.PollAnswers(context.Background(), types.NewQueryPollAnswersRequest(subspaceID, postID, pollID, user, pageReq))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description
This PR fixes a bug within the CLI command to query the poll answers.

Closes: #928

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)