### PR TITLE
chore: fix x/reactions events

### DIFF
--- a/.changeset/entries/e2fa8c09bd5014df0ee3eadc345fd6d139a7196709dd70539791c2154a36a2af.yaml
+++ b/.changeset/entries/e2fa8c09bd5014df0ee3eadc345fd6d139a7196709dd70539791c2154a36a2af.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/reactions
+pull_request: 940
+description: Fixed wrong event types and missing attributes
+backward_compatible: true
+date: 2022-06-27T12:20:12.588100075Z

--- a/x/reactions/keeper/msg_server.go
+++ b/x/reactions/keeper/msg_server.go
@@ -99,6 +99,7 @@ func (k msgServer) AddReaction(goCtx context.Context, msg *types.MsgAddReaction)
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
 			sdk.NewAttribute(types.AttributeKeyReactionID, fmt.Sprintf("%d", reaction.ID)),
+			sdk.NewAttribute(types.AttributeKeyUser, msg.User),
 		),
 	})
 
@@ -293,7 +294,7 @@ func (k msgServer) RemoveRegisteredReaction(goCtx context.Context, msg *types.Ms
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
 		),
 		sdk.NewEvent(
-			types.ActionRemoveRegisteredReaction,
+			types.EventTypeRemoveRegisteredReaction,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyRegisteredReactionID, fmt.Sprintf("%d", msg.RegisteredReactionID)),
 		),
@@ -334,7 +335,7 @@ func (k msgServer) SetReactionsParams(goCtx context.Context, msg *types.MsgSetRe
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
 		),
 		sdk.NewEvent(
-			types.ActionSetReactionParams,
+			types.EventTypeSetReactionsParams,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 		),
 	})

--- a/x/reactions/keeper/msg_server_test.go
+++ b/x/reactions/keeper/msg_server_test.go
@@ -374,6 +374,7 @@ func (suite *KeeperTestSuite) TestMsgServer_AddReaction() {
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
 					sdk.NewAttribute(types.AttributeKeyReactionID, "1"),
+					sdk.NewAttribute(types.AttributeKeyUser, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
 				),
 			},
 			check: func(ctx sdk.Context) {
@@ -457,6 +458,7 @@ func (suite *KeeperTestSuite) TestMsgServer_AddReaction() {
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
 					sdk.NewAttribute(types.AttributeKeyReactionID, "1"),
+					sdk.NewAttribute(types.AttributeKeyUser, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
 				),
 			},
 			check: func(ctx sdk.Context) {
@@ -1252,7 +1254,7 @@ func (suite *KeeperTestSuite) TestMsgServer_RemoveRegisteredReaction() {
 					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
 				),
 				sdk.NewEvent(
-					types.ActionRemoveRegisteredReaction,
+					types.EventTypeRemoveRegisteredReaction,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyRegisteredReactionID, "1"),
 				),
@@ -1390,7 +1392,7 @@ func (suite *KeeperTestSuite) TestMsgServer_SetReactionsParams() {
 					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
 				),
 				sdk.NewEvent(
-					types.ActionSetReactionParams,
+					types.EventTypeSetReactionsParams,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 				),
 			},


### PR DESCRIPTION
## Description

This PR fixes the `x/reactions` events types and missing attributes.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)