### PR TITLE
fix: remove position validation from post entities and references

### DIFF
--- a/.changeset/entries/746e35e47af0507db333384fe80011d6170bc2c7ffb4c742da6d9d8b2513f586.yaml
+++ b/.changeset/entries/746e35e47af0507db333384fe80011d6170bc2c7ffb4c742da6d9d8b2513f586.yaml
@@ -1,7 +1,6 @@
 type: fix
 module: x/posts
 pull_request: 941
-description: Allow to specify start and end indexes of tags even when a post test
-  is stored outside the chain
+description: Allow to specify start and end indexes of tags and post references even when a post text is stored outside the chain
 backward_compatible: true
 date: 2022-06-27T12:29:24.898824942Z

--- a/.changeset/entries/746e35e47af0507db333384fe80011d6170bc2c7ffb4c742da6d9d8b2513f586.yaml
+++ b/.changeset/entries/746e35e47af0507db333384fe80011d6170bc2c7ffb4c742da6d9d8b2513f586.yaml
@@ -1,0 +1,7 @@
+type: fix
+module: x/posts
+pull_request: 941
+description: Allow to specify start and end indexes of tags even when a post test
+  is stored outside the chain
+backward_compatible: true
+date: 2022-06-27T12:29:24.898824942Z

--- a/x/posts/types/models.go
+++ b/x/posts/types/models.go
@@ -72,18 +72,6 @@ func (p Post) Validate() error {
 		if err != nil {
 			return fmt.Errorf("invalid entities: %s", err)
 		}
-
-		// Make sure that no entity has a start or end index that is greater to the text length
-		maxIndexAllowed := uint64(0)
-		if len(strings.TrimSpace(p.Text)) > 0 {
-			maxIndexAllowed = uint64(len(strings.TrimSpace(p.Text)) - 1)
-		}
-
-		for _, segment := range p.Entities.getSegments() {
-			if segment.start > maxIndexAllowed || segment.end > maxIndexAllowed {
-				return fmt.Errorf("entity cannot have start/end index greater than text length")
-			}
-		}
 	}
 
 	_, err := sdk.AccAddressFromBech32(p.Author)
@@ -103,10 +91,6 @@ func (p Post) Validate() error {
 
 		if reference.PostID >= p.ID {
 			return fmt.Errorf("invalid referenced post id: %d", reference.PostID)
-		}
-
-		if reference.Position > uint64(len(p.Text)) {
-			return fmt.Errorf("invalid reference position: %d", reference.Position)
 		}
 	}
 

--- a/x/posts/types/models_test.go
+++ b/x/posts/types/models_test.go
@@ -107,66 +107,6 @@ func TestPost_Validate(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			name: "invalid hashtag index returns error",
-			post: types.NewPost(
-				1,
-				0,
-				2,
-				"External id",
-				"Text",
-				"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg",
-				1,
-				types.NewEntities([]types.Tag{
-					types.NewTag(1, 10, "tag"),
-				}, nil, nil),
-				nil,
-				types.REPLY_SETTING_EVERYONE,
-				time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
-				nil,
-			),
-			shouldErr: true,
-		},
-		{
-			name: "invalid mention index returns error",
-			post: types.NewPost(
-				1,
-				0,
-				2,
-				"External id",
-				"Text",
-				"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg",
-				1,
-				types.NewEntities(nil, []types.Tag{
-					types.NewTag(10, 1, "tag"),
-				}, nil),
-				nil,
-				types.REPLY_SETTING_EVERYONE,
-				time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
-				nil,
-			),
-			shouldErr: true,
-		},
-		{
-			name: "invalid url index returns error",
-			post: types.NewPost(
-				1,
-				0,
-				2,
-				"External id",
-				"Text",
-				"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg",
-				1,
-				types.NewEntities(nil, nil, []types.Url{
-					types.NewURL(10, 1, "URL", "Display URL"),
-				}),
-				nil,
-				types.REPLY_SETTING_EVERYONE,
-				time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
-				nil,
-			),
-			shouldErr: true,
-		},
-		{
 			name: "invalid author address returns error",
 			post: types.NewPost(
 				1,
@@ -271,34 +211,6 @@ func TestPost_Validate(t *testing.T) {
 				),
 				[]types.PostReference{
 					types.NewPostReference(types.POST_REFERENCE_TYPE_QUOTE, 2, 0),
-				},
-				types.REPLY_SETTING_EVERYONE,
-				time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
-				nil,
-			),
-			shouldErr: true,
-		},
-		{
-			name: "invalid reference position returns error",
-			post: types.NewPost(
-				1,
-				0,
-				2,
-				"External id",
-				"Text",
-				"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg",
-				1,
-				types.NewEntities(
-					[]types.Tag{
-						types.NewTag(1, 1, "tag"),
-					},
-					[]types.Tag{
-						types.NewTag(2, 3, "tag"),
-					},
-					nil,
-				),
-				[]types.PostReference{
-					types.NewPostReference(types.POST_REFERENCE_TYPE_QUOTE, 1, 1000),
 				},
 				types.REPLY_SETTING_EVERYONE,
 				time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),


### PR DESCRIPTION
## Description

This PR removes the position validation from within a post's entities. This is done to make sure that DApps that store the post's text on other places (i.e. IPFS or any external storage) can use the tags properly. 

Before, it wasn't possible to use a tag specifying `start` and `end` values that where exceeding a post `text` length. But for posts that store their text on other storage solutions, it doesn't make sense to check for this. Instead, allowing to specify arbitrary values for `start` and `end` indexes allows to support these cases as well. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)