### PR TITLE
fix: added missing unlink wasm msgs parser

### DIFF
--- a/.changeset/entries/a95f200d5bb4f0ae79b9f221e0ef22e7266af1b3064faeca87fcaa56168079f1.yaml
+++ b/.changeset/entries/a95f200d5bb4f0ae79b9f221e0ef22e7266af1b3064faeca87fcaa56168079f1.yaml
@@ -1,6 +1,6 @@
 type: fix
 module: x/profiles
 pull_request: 954
-description: Added missing unlink messages wasm parser
+description: Added missing unlink messages WASM parsers
 backward_compatible: true
 date: 2022-07-04T05:29:58.5106104Z

--- a/.changeset/entries/a95f200d5bb4f0ae79b9f221e0ef22e7266af1b3064faeca87fcaa56168079f1.yaml
+++ b/.changeset/entries/a95f200d5bb4f0ae79b9f221e0ef22e7266af1b3064faeca87fcaa56168079f1.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/profiles
+pull_request: 954
+description: Added missing unlink messages wasm parser
+backward_compatible: true
+date: 2022-07-04T05:29:58.5106104Z

--- a/x/profiles/types/wasm.go
+++ b/x/profiles/types/wasm.go
@@ -12,7 +12,9 @@ type ProfilesMsg struct {
 	RefuseDtagTransferRequest *json.RawMessage `json:"refuse_dtag_transfer_request"`
 	CancelDtagTransferRequest *json.RawMessage `json:"cancel_dtag_transfer_request"`
 	LinkChainAccount          *json.RawMessage `json:"link_chain_account"`
+	UnlinkChainAccount        *json.RawMessage `json:"unlink_chain_account"`
 	LinkApplication           *json.RawMessage `json:"link_application"`
+	UnlinkApplication         *json.RawMessage `json:"unlink_application"`
 }
 
 type ProfilesQuery struct {

--- a/x/profiles/wasm/common_test.go
+++ b/x/profiles/wasm/common_test.go
@@ -75,9 +75,21 @@ func buildLinkChainAccountRequest(cdc codec.Codec, msg sdk.Msg) json.RawMessage 
 	return bz
 }
 
+func buildUnlinkChainAccountRequest(cdc codec.Codec, msg sdk.Msg) json.RawMessage {
+	raw := json.RawMessage(cdc.MustMarshalJSON(msg))
+	bz, _ := json.Marshal(types.ProfilesMsg{UnlinkChainAccount: &raw})
+	return bz
+}
+
 func buildLinkApplicationRequest(cdc codec.Codec, msg sdk.Msg) json.RawMessage {
 	raw := json.RawMessage(cdc.MustMarshalJSON(msg))
 	bz, _ := json.Marshal(types.ProfilesMsg{LinkApplication: &raw})
+	return bz
+}
+
+func buildUnlinkApplicationRequest(cdc codec.Codec, msg sdk.Msg) json.RawMessage {
+	raw := json.RawMessage(cdc.MustMarshalJSON(msg))
+	bz, _ := json.Marshal(types.ProfilesMsg{UnlinkApplication: &raw})
 	return bz
 }
 

--- a/x/profiles/wasm/msg_parser.go
+++ b/x/profiles/wasm/msg_parser.go
@@ -46,8 +46,12 @@ func (parser MsgsParser) ParseCustomMsgs(contractAddr sdk.AccAddress, data json.
 		return commons.HandleWasmMsg(parser.cdc, *msg.CancelDtagTransferRequest, &types.MsgCancelDTagTransferRequest{})
 	case msg.LinkChainAccount != nil:
 		return commons.HandleWasmMsg(parser.cdc, *msg.LinkChainAccount, &types.MsgLinkChainAccount{})
+	case msg.UnlinkChainAccount != nil:
+		return commons.HandleWasmMsg(parser.cdc, *msg.LinkChainAccount, &types.MsgUnlinkChainAccount{})
 	case msg.LinkApplication != nil:
 		return commons.HandleWasmMsg(parser.cdc, *msg.LinkApplication, &types.MsgLinkApplication{})
+	case msg.UnlinkApplication != nil:
+		return commons.HandleWasmMsg(parser.cdc, *msg.LinkChainAccount, &types.MsgUnlinkApplication{})
 	default:
 		return nil, sdkerrors.Wrap(wasm.ErrInvalidMsg, "cosmwasm-profiles-msg-parser: message not supported")
 	}

--- a/x/profiles/wasm/msg_parser.go
+++ b/x/profiles/wasm/msg_parser.go
@@ -47,11 +47,11 @@ func (parser MsgsParser) ParseCustomMsgs(contractAddr sdk.AccAddress, data json.
 	case msg.LinkChainAccount != nil:
 		return commons.HandleWasmMsg(parser.cdc, *msg.LinkChainAccount, &types.MsgLinkChainAccount{})
 	case msg.UnlinkChainAccount != nil:
-		return commons.HandleWasmMsg(parser.cdc, *msg.LinkChainAccount, &types.MsgUnlinkChainAccount{})
+		return commons.HandleWasmMsg(parser.cdc, *msg.UnlinkChainAccount, &types.MsgUnlinkChainAccount{})
 	case msg.LinkApplication != nil:
 		return commons.HandleWasmMsg(parser.cdc, *msg.LinkApplication, &types.MsgLinkApplication{})
 	case msg.UnlinkApplication != nil:
-		return commons.HandleWasmMsg(parser.cdc, *msg.LinkChainAccount, &types.MsgUnlinkApplication{})
+		return commons.HandleWasmMsg(parser.cdc, *msg.UnlinkApplication, &types.MsgUnlinkApplication{})
 	default:
 		return nil, sdkerrors.Wrap(wasm.ErrInvalidMsg, "cosmwasm-profiles-msg-parser: message not supported")
 	}

--- a/x/profiles/wasm/msg_parser_test.go
+++ b/x/profiles/wasm/msg_parser_test.go
@@ -192,7 +192,7 @@ func TestMsgsParser_ParseCustomMsgs(t *testing.T) {
 		},
 		{
 			name: "unlink application json message is parsed correctly",
-			msg: buildUnlinkChainAccountRequest(cdc, types.NewMsgUnlinkApplication(
+			msg: buildUnlinkApplicationRequest(cdc, types.NewMsgUnlinkApplication(
 				"twitter",
 				"twitteruser",
 				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",

--- a/x/profiles/wasm/msg_parser_test.go
+++ b/x/profiles/wasm/msg_parser_test.go
@@ -153,6 +153,20 @@ func TestMsgsParser_ParseCustomMsgs(t *testing.T) {
 			},
 		},
 		{
+			name: "unlink chain account json message is parsed correctly",
+			msg: buildUnlinkChainAccountRequest(cdc, types.NewMsgUnlinkChainAccount(
+				"cosmos1u9hgsqfpe3snftr7p7fsyja3wtlmj2sgf2w9yl",
+				"cosmos",
+				"cosmos1xmquc944hzu6n6qtljcexkuhhz76mucxtgm5x0",
+			)),
+			shouldErr: false,
+			expMsgs: []sdk.Msg{types.NewMsgUnlinkChainAccount(
+				"cosmos1u9hgsqfpe3snftr7p7fsyja3wtlmj2sgf2w9yl",
+				"cosmos",
+				"cosmos1xmquc944hzu6n6qtljcexkuhhz76mucxtgm5x0",
+			)},
+		},
+		{
 			name: "link application json message is parsed correctly",
 			msg: buildLinkApplicationRequest(cdc, types.NewMsgLinkApplication(
 				types.NewData("twitter", "twitteruser"),
@@ -175,6 +189,20 @@ func TestMsgsParser_ParseCustomMsgs(t *testing.T) {
 					0,
 				),
 			},
+		},
+		{
+			name: "unlink application json message is parsed correctly",
+			msg: buildUnlinkChainAccountRequest(cdc, types.NewMsgUnlinkApplication(
+				"twitter",
+				"twitteruser",
+				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+			)),
+			shouldErr: false,
+			expMsgs: []sdk.Msg{types.NewMsgUnlinkApplication(
+				"twitter",
+				"twitteruser",
+				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
+			)},
 		},
 	}
 


### PR DESCRIPTION
## Description

Closes: #XXXX
This PR added missing wasm `x/profiles` unlink msgs parser. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)