### PR TITLE
chore: fix wrong names inside reports CLI commands

### DIFF
--- a/x/reports/client/cli/query.go
+++ b/x/reports/client/cli/query.go
@@ -37,7 +37,7 @@ func GetQueryCmd() *cobra.Command {
 // GetCmdQueryReport returns the command to query a report of a subspace
 func GetCmdQueryReport() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "reports [subspace-id] [report-id]",
+		Use:     "report [subspace-id] [report-id]",
 		Short:   "Query the report having the given id",
 		Example: fmt.Sprintf(`%s query reports report 1 1`, version.AppName),
 		Args:    cobra.ExactArgs(2),
@@ -134,7 +134,7 @@ func GetCmdQueryReports() *cobra.Command {
 // GetCmdQueryReason returns the command to query a reason of a subspace
 func GetCmdQueryReason() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "reasons [subspace-id] [reason-id]",
+		Use:     "reason [subspace-id] [reason-id]",
 		Short:   "Query the reason having the given id",
 		Example: fmt.Sprintf(`%s query reports reason 1 1`, version.AppName),
 		Args:    cobra.ExactArgs(2),

--- a/x/reports/client/cli/tx.go
+++ b/x/reports/client/cli/tx.go
@@ -53,8 +53,8 @@ To report a post, --%s must be used instead.`, FlagUser, FlagPostID),
   --from alice
 
 %[1]s tx reports report 1 1,2,3 \
-  --%s 1 \
-  --message "This port is spam" \
+  --%[3]s 1 \
+  --message "This post is spam" \
   --from alice
 `, version.AppName, FlagUser, FlagPostID),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -114,7 +114,7 @@ func GetCmdDeleteReport() *cobra.Command {
 		Args:    cobra.ExactArgs(2),
 		Short:   "Delete a report",
 		Long:    "Delete the report having the given id from the specified subspace",
-		Example: fmt.Sprintf(`%s tx reports delete-report 1 1 --from alice`, version.AppName),
+		Example: fmt.Sprintf(`%s tx reports delete 1 1 --from alice`, version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {


### PR DESCRIPTION
## Description

Closes: #XXXX

This PR fixes some example descriptions in tx commands and some query commands names that collides with others.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)