### PR TITLE
chore: fix `x/reactions` CLI commands examples

### DIFF
--- a/x/reactions/client/cli/query.go
+++ b/x/reactions/client/cli/query.go
@@ -89,8 +89,8 @@ func GetCmdQueryReaction() *cobra.Command {
 // GetCmdQueryReactions returns the command to query the reactions inside a subspace
 func GetCmdQueryReactions() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "reactions [subspace-id] [post-id]",
-		Short: "Query the reactions inside the specified subspace with an optional post id",
+		Use:   "reactions [subspace-id] [[post-id]]",
+		Short: "Query the reactions inside the specified subspace with an optional post id and an optional user",
 		Example: fmt.Sprintf(`
 %s query reactions reactions 1 1 --%s=cosmos14z8mn9ywhqu84alr5grxuljwj87jyz0zpxnlxy
 `, version.AppName, FlagUser),

--- a/x/reactions/client/cli/tx.go
+++ b/x/reactions/client/cli/tx.go
@@ -56,8 +56,8 @@ func GetCmdAddReaction() *cobra.Command {
 Add a reaction to the post with the given id inside the specified subspace.
 In order to specify the reaction value, either --%s or --%s must be used`, FlagRegisteredReaction, FlagFreeTextReaction),
 		Example: fmt.Sprintf(`
-%[1]s tx reactions add 1 --%[2]s 1 --from alice
-%[1]s tx reactions add 1 --%[3]s "🚀" --from alice
+%[1]s tx reactions add 1 2 --%[2]s 1 --from alice
+%[1]s tx reactions add 1 2 --%[3]s "🚀" --from alice
 `, version.AppName, FlagRegisteredReaction, FlagFreeTextReaction),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
@@ -191,7 +191,7 @@ func GetCmdAddRegisteredReaction() *cobra.Command {
 		Args:    cobra.ExactArgs(3),
 		Short:   "Register a new reaction",
 		Long:    "Register a new reaction with the specified shorthand code and display value inside the given subspace",
-		Example: fmt.Sprintf(`%s tx reactions registered add 1 1 ":hello" "https://example.com?image=hello.png" --from alice`, version.AppName),
+		Example: fmt.Sprintf(`%s tx reactions registered add 1 ":hello:" "https://example.com?image=hello.png" --from alice`, version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -284,7 +284,7 @@ func GetCmdRemoveRegisteredReaction() *cobra.Command {
 		Use:     "remove [subspace-id] [reaction-id]",
 		Args:    cobra.ExactArgs(2),
 		Short:   "Remove a registered reaction from a subspace",
-		Example: fmt.Sprintf(`%s tx reactions registered 1 1 --from alice`, version.AppName),
+		Example: fmt.Sprintf(`%s tx reactions registered remove 1 1 --from alice`, version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {


### PR DESCRIPTION
## Description

Closes: #XXXX

Minor fixes to CLI commands examples of `x/reactions` module.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)