### PR TITLE
fix: fix json fields naming of ReportsMsg

### DIFF
--- a/x/reports/types/wasm.go
+++ b/x/reports/types/wasm.go
@@ -3,8 +3,8 @@ package types
 import "encoding/json"
 
 type ReportsMsg struct {
-	CreateReport          *json.RawMessage `json:"create_post"`
-	DeleteReport          *json.RawMessage `json:"edit_post"`
+	CreateReport          *json.RawMessage `json:"create_report"`
+	DeleteReport          *json.RawMessage `json:"delete_report"`
 	SupportStandardReason *json.RawMessage `json:"support_standard_reason"`
 	AddReason             *json.RawMessage `json:"add_reason"`
 	RemoveReason          *json.RawMessage `json:"remove_reason"`


### PR DESCRIPTION
## Description

Fixed the json field naming of the struct `ReportsMsg` used to deserilize the messages received from cosmwasm.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)