### PR TITLE
fix!: profile query returns nil if profile does not exist

### DIFF
--- a/.changeset/entries/e8fdc65b9f41e85409395d7e7b317f59f6d7be1ff3f8a92ebb30dafeb3254d4e.yaml
+++ b/.changeset/entries/e8fdc65b9f41e85409395d7e7b317f59f6d7be1ff3f8a92ebb30dafeb3254d4e.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/profiles
+pull_request: 971
+description: fix profile query returns nil to error if profile does not exist
+backward_compatible: true
+date: 2022-07-22T06:27:36.4265228Z

--- a/.changeset/entries/e8fdc65b9f41e85409395d7e7b317f59f6d7be1ff3f8a92ebb30dafeb3254d4e.yaml
+++ b/.changeset/entries/e8fdc65b9f41e85409395d7e7b317f59f6d7be1ff3f8a92ebb30dafeb3254d4e.yaml
@@ -1,6 +1,6 @@
 type: fix
 module: x/profiles
 pull_request: 971
-description: fix profile query returns nil to error if profile does not exist
-backward_compatible: true
+description: `QueryProfile` now returns an error instead of `nil` when a profile is not found
+backward_compatible: false
 date: 2022-07-22T06:27:36.4265228Z

--- a/x/profiles/client/cli/cli_profile_test.go
+++ b/x/profiles/client/cli/cli_profile_test.go
@@ -51,10 +51,7 @@ func (s *IntegrationTestSuite) TestCmdQueryProfile() {
 				s.network.Validators[1].Address.String(),
 				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 			},
-			shouldErr: false,
-			expectedOutput: types.QueryProfileResponse{
-				Profile: nil,
-			},
+			shouldErr: true,
 		},
 		{
 			name: "existing profile is returned properly",

--- a/x/profiles/keeper/grpc_query.go
+++ b/x/profiles/keeper/grpc_query.go
@@ -47,7 +47,7 @@ func (k Keeper) Profile(ctx context.Context, request *types.QueryProfileRequest)
 	}
 
 	if !found {
-		return &types.QueryProfileResponse{Profile: nil}, nil
+		return nil, status.Errorf(codes.NotFound, "profile for dtag/address %s not found", dTagOrAddress)
 	}
 
 	accountAny, err := codectypes.NewAnyWithValue(account)

--- a/x/profiles/keeper/grpc_query_test.go
+++ b/x/profiles/keeper/grpc_query_test.go
@@ -30,10 +30,9 @@ func (suite *KeeperTestSuite) TestQueryServer_Profile() {
 			shouldErr: true,
 		},
 		{
-			name:        "profile not found",
-			req:         types.NewQueryProfileRequest("cosmos19mj6dkd85m84gxvf8d929w572z5h9q0u8d8wpa"),
-			shouldErr:   false,
-			expResponse: &types.QueryProfileResponse{Profile: nil},
+			name:      "profile not found returns error",
+			req:       types.NewQueryProfileRequest("cosmos19mj6dkd85m84gxvf8d929w572z5h9q0u8d8wpa"),
+			shouldErr: true,
 		},
 		{
 			name: "found profile using DTag",


### PR DESCRIPTION
## Description

Currently, querying a non-existing profile returns `nil` instead of error with `profile not found for address/dtag`.
This PR fixes the response of `Profile` behavior mentioned above. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)