### PR TITLE
build(ci): fix lint workflow to use make lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,10 +31,5 @@ jobs:
             .sum
 
       - name: Run lint ✅
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.28
-          args: --timeout 10m
-          github-token: ${{ secrets.github_token }}
         if: "env.GIT_DIFF != ''"
+        run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,13 +53,10 @@ issues:
         - stylecheck
 
     # TODO: Remove these when we are ready to drop support for Legacy Amino
-    - text: "SA1019: codec.LegacyAmino is deprecated"
+    - text: 'SA1019: "github.com/cosmos/cosmos-sdk/types/bech32/legacybech32" is deprecated'
       linters:
         - staticcheck
     - text: "SA1019: legacybech32.UnmarshalPubKey is deprecated"
-      linters:
-        - staticcheck
-    - text: "SA1019: package github.com/cosmos/cosmos-sdk/types/bech32/legacybech32 is deprecated"
       linters:
         - staticcheck
 


### PR DESCRIPTION
## Description

This PR updates the GitHub lint workflow to use `make lint` instead of `golangci-lint-action`. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)