### PR TITLE
feat!: implement account creation in `x/subspaces`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -494,7 +494,7 @@ func NewDesmosApp(
 	app.FeesKeeper = feeskeeper.NewKeeper(app.appCodec, app.GetSubspace(feestypes.ModuleName))
 
 	// Create subspaces keeper and module
-	subspacesKeeper := subspaceskeeper.NewKeeper(app.appCodec, keys[subspacestypes.StoreKey])
+	subspacesKeeper := subspaceskeeper.NewKeeper(app.appCodec, keys[subspacestypes.StoreKey], app.AccountKeeper)
 
 	// Create the relationships keeper
 	app.RelationshipsKeeper = relationshipskeeper.NewKeeper(

--- a/x/posts/abci_test.go
+++ b/x/posts/abci_test.go
@@ -56,9 +56,9 @@ func TestEndBlocker(t *testing.T) {
 	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "test-chain"}, false, log.NewNopLogger())
 	cdc, legacyAmino := app.MakeCodecs()
 	pk := paramskeeper.NewKeeper(cdc, legacyAmino, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey])
-	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey])
-	rk := relationshipskeeper.NewKeeper(cdc, keys[relationshipstypes.StoreKey], sk)
 	authKeeper := authkeeper.NewAccountKeeper(cdc, keys[authtypes.StoreKey], pk.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
+	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey], authKeeper)
+	rk := relationshipskeeper.NewKeeper(cdc, keys[relationshipstypes.StoreKey], sk)
 	profilesKeeper := profileskeeper.NewKeeper(cdc, legacyAmino, keys[profilestypes.StoreKey], pk.Subspace(profilestypes.DefaultParamsSpace), authKeeper, rk, nil, nil, nil)
 	keeper := postskeeper.NewKeeper(cdc, keys[poststypes.StoreKey], pk.Subspace(types.DefaultParamsSpace), profilesKeeper, sk, rk)
 

--- a/x/posts/keeper/common_test.go
+++ b/x/posts/keeper/common_test.go
@@ -77,7 +77,7 @@ func (suite *KeeperTestsuite) SetupTest() {
 	paramsKeeper := paramskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey])
 
 	authKeeper := authkeeper.NewAccountKeeper(suite.cdc, keys[authtypes.StoreKey], paramsKeeper.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
 	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
 	suite.ak = profileskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[profilestypes.StoreKey], paramsKeeper.Subspace(profilestypes.DefaultParamsSpace), authKeeper, suite.rk, nil, nil, nil)
 	suite.k = keeper.NewKeeper(

--- a/x/posts/legacy/v2/store_test.go
+++ b/x/posts/legacy/v2/store_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -23,7 +25,7 @@ func TestMigrateStore(t *testing.T) {
 	cdc, amino := app.MakeCodecs()
 
 	// Build all the necessary keys
-	keys := sdk.NewKVStoreKeys(paramstypes.StoreKey, subspacestypes.StoreKey, types.StoreKey)
+	keys := sdk.NewKVStoreKeys(paramstypes.StoreKey, subspacestypes.StoreKey, types.StoreKey, authtypes.StoreKey)
 	tKeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
 	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
 
@@ -31,7 +33,8 @@ func TestMigrateStore(t *testing.T) {
 	paramsSubspace := pk.Subspace(types.ModuleName)
 	paramsSubspace = paramsSubspace.WithKeyTable(types.ParamKeyTable())
 
-	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey])
+	authKeeper := authkeeper.NewAccountKeeper(cdc, keys[authtypes.StoreKey], pk.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
+	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey], authKeeper)
 
 	testCases := []struct {
 		name      string

--- a/x/posts/wasm/common_test.go
+++ b/x/posts/wasm/common_test.go
@@ -146,7 +146,7 @@ func (suite *TestSuite) SetupTest() {
 	paramsKeeper := paramskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey])
 
 	authKeeper := authkeeper.NewAccountKeeper(suite.cdc, keys[authtypes.StoreKey], paramsKeeper.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
 	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
 	suite.ak = profileskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[profilestypes.StoreKey], paramsKeeper.Subspace(profilestypes.DefaultParamsSpace), authKeeper, suite.rk, nil, nil, nil)
 	suite.k = keeper.NewKeeper(

--- a/x/profiles/abci_test.go
+++ b/x/profiles/abci_test.go
@@ -54,9 +54,9 @@ func TestBeginBlocker(t *testing.T) {
 	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "test-chain"}, false, log.NewNopLogger())
 	cdc, legacyAmino := app.MakeCodecs()
 	pk := paramskeeper.NewKeeper(cdc, legacyAmino, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey])
-	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey])
-	rk := relationshipskeeper.NewKeeper(cdc, keys[relationshipstypes.StoreKey], sk)
 	ak := authkeeper.NewAccountKeeper(cdc, keys[authtypes.StoreKey], pk.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
+	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey], ak)
+	rk := relationshipskeeper.NewKeeper(cdc, keys[relationshipstypes.StoreKey], sk)
 	k := keeper.NewKeeper(cdc, legacyAmino, keys[types.StoreKey], pk.Subspace(types.DefaultParamsSpace), ak, rk, nil, nil, nil)
 
 	testCases := []struct {

--- a/x/profiles/keeper/common_test.go
+++ b/x/profiles/keeper/common_test.go
@@ -174,7 +174,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 		scopedIBCKeeper,
 	)
 
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], suite.ak)
 	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
 	suite.k = keeper.NewKeeper(
 		suite.cdc,

--- a/x/profiles/types/expected_keeper.go
+++ b/x/profiles/types/expected_keeper.go
@@ -6,20 +6,9 @@ import (
 	connectiontypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v3/modules/core/exported"
-
-	subspacestypes "github.com/desmos-labs/desmos/v4/x/subspaces/types"
 )
 
 // DONTCOVER
-
-// SubspacesKeeper represents the expected keeper used to interact with subspaces
-type SubspacesKeeper interface {
-	// HasSubspace tells if the subspace with the given id exists
-	HasSubspace(ctx sdk.Context, subspaceID uint64) bool
-
-	// GetAllSubspaces returns all the subspaces stored
-	GetAllSubspaces(ctx sdk.Context) []subspacestypes.Subspace
-}
 
 // RelationshipsKeeper represents the expected keeper used to interact with relationships
 type RelationshipsKeeper interface {

--- a/x/profiles/wasm/common_test.go
+++ b/x/profiles/wasm/common_test.go
@@ -255,7 +255,7 @@ func (suite *TestSuite) SetupTest() {
 		scopedIBCKeeper,
 	)
 
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], suite.ak)
 	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
 	suite.k = keeper.NewKeeper(
 		suite.cdc,

--- a/x/reactions/keeper/common_test.go
+++ b/x/reactions/keeper/common_test.go
@@ -97,7 +97,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	authKeeper := authkeeper.NewAccountKeeper(suite.cdc, keys[authtypes.StoreKey], paramsKeeper.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
 	suite.ak = profileskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[profilestypes.StoreKey], paramsKeeper.Subspace(profilestypes.DefaultParamsSpace), authKeeper, suite.rk, nil, nil, nil)
 	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
 	suite.pk = postskeeper.NewKeeper(
 		suite.cdc,
 		keys[poststypes.StoreKey],

--- a/x/reactions/legacy/v2/store_test.go
+++ b/x/reactions/legacy/v2/store_test.go
@@ -39,7 +39,7 @@ func TestMigrateStore(t *testing.T) {
 	paramsKeeper := paramskeeper.NewKeeper(cdc, legacyAminoCdc, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey])
 	authKeeper := authkeeper.NewAccountKeeper(cdc, keys[authtypes.StoreKey], paramsKeeper.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
 
-	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey])
+	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey], authKeeper)
 	rk := relationshipskeeper.NewKeeper(cdc, keys[relationshipstypes.StoreKey], sk)
 	ak := profileskeeper.NewKeeper(cdc, legacyAminoCdc, keys[profilestypes.StoreKey], paramsKeeper.Subspace(profilestypes.DefaultParamsSpace), authKeeper, rk, nil, nil, nil)
 	pk := postskeeper.NewKeeper(cdc, keys[poststypes.StoreKey], paramsKeeper.Subspace(poststypes.DefaultParamsSpace), ak, sk, rk)

--- a/x/reactions/wasm/common_test.go
+++ b/x/reactions/wasm/common_test.go
@@ -155,7 +155,7 @@ func (suite *Testsuite) SetupTest() {
 	authKeeper := authkeeper.NewAccountKeeper(suite.cdc, keys[authtypes.StoreKey], paramsKeeper.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
 	suite.ak = profileskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[profilestypes.StoreKey], paramsKeeper.Subspace(profilestypes.DefaultParamsSpace), authKeeper, suite.rk, nil, nil, nil)
 	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
 	suite.pk = postskeeper.NewKeeper(
 		suite.cdc,
 		keys[poststypes.StoreKey],

--- a/x/relationships/keeper/common_test.go
+++ b/x/relationships/keeper/common_test.go
@@ -102,6 +102,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 		nil,
 		nil,
 	)
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
 	suite.k = keeper.NewKeeper(suite.cdc, suite.storeKey, suite.sk)
 }

--- a/x/relationships/wasm/common_test.go
+++ b/x/relationships/wasm/common_test.go
@@ -135,6 +135,6 @@ func (suite *TestSuite) SetupTest() {
 		nil,
 		nil,
 	)
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
 	suite.k = keeper.NewKeeper(suite.cdc, suite.storeKey, suite.sk)
 }

--- a/x/reports/keeper/common_test.go
+++ b/x/reports/keeper/common_test.go
@@ -78,10 +78,10 @@ func (suite *KeeperTestsuite) SetupTest() {
 	paramsKeeper := paramskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey])
 
 	// Define keeper
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
-	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
 	authKeeper := authkeeper.NewAccountKeeper(suite.cdc, keys[authtypes.StoreKey], paramsKeeper.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
 	suite.ak = profileskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[profilestypes.StoreKey], paramsKeeper.Subspace(profilestypes.DefaultParamsSpace), authKeeper, suite.rk, nil, nil, nil)
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
+	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
 	suite.pk = postskeeper.NewKeeper(suite.cdc, keys[poststypes.StoreKey], paramsKeeper.Subspace(poststypes.DefaultParamsSpace), suite.ak, suite.sk, suite.rk)
 	suite.k = keeper.NewKeeper(
 		suite.cdc,

--- a/x/reports/legacy/v2/store_test.go
+++ b/x/reports/legacy/v2/store_test.go
@@ -11,6 +11,9 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/stretchr/testify/require"
 
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
 	"github.com/desmos-labs/desmos/v4/app"
 	"github.com/desmos-labs/desmos/v4/testutil/storetesting"
 	v2 "github.com/desmos-labs/desmos/v4/x/reports/legacy/v2"
@@ -23,7 +26,7 @@ func TestMigrateStore(t *testing.T) {
 	cdc, amino := app.MakeCodecs()
 
 	// Build all the necessary keys
-	keys := sdk.NewKVStoreKeys(paramstypes.StoreKey, subspacestypes.StoreKey, types.StoreKey)
+	keys := sdk.NewKVStoreKeys(paramstypes.StoreKey, subspacestypes.StoreKey, authtypes.StoreKey, types.StoreKey)
 	tKeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
 	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
 
@@ -31,7 +34,8 @@ func TestMigrateStore(t *testing.T) {
 	paramsSubspace := pk.Subspace(types.ModuleName)
 	paramsSubspace = paramsSubspace.WithKeyTable(types.ParamKeyTable())
 
-	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey])
+	authKeeper := authkeeper.NewAccountKeeper(cdc, keys[authtypes.StoreKey], pk.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
+	sk := subspaceskeeper.NewKeeper(cdc, keys[subspacestypes.StoreKey], authKeeper)
 
 	testCases := []struct {
 		name      string

--- a/x/reports/wasm/common_test.go
+++ b/x/reports/wasm/common_test.go
@@ -133,9 +133,10 @@ func (suite *Testsuite) SetupTest() {
 	paramsKeeper := paramskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey])
 
 	// Define keeper
-	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey])
-	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
+
 	authKeeper := authkeeper.NewAccountKeeper(suite.cdc, keys[authtypes.StoreKey], paramsKeeper.Subspace(authtypes.ModuleName), authtypes.ProtoBaseAccount, app.GetMaccPerms())
+	suite.sk = subspaceskeeper.NewKeeper(suite.cdc, keys[subspacestypes.StoreKey], authKeeper)
+	suite.rk = relationshipskeeper.NewKeeper(suite.cdc, keys[relationshipstypes.StoreKey], suite.sk)
 	suite.ak = profileskeeper.NewKeeper(suite.cdc, suite.legacyAminoCdc, keys[profilestypes.StoreKey], paramsKeeper.Subspace(profilestypes.DefaultParamsSpace), authKeeper, suite.rk, nil, nil, nil)
 	suite.pk = postskeeper.NewKeeper(suite.cdc, keys[poststypes.StoreKey], paramsKeeper.Subspace(poststypes.DefaultParamsSpace), suite.ak, suite.sk, suite.rk)
 	suite.k = keeper.NewKeeper(

--- a/x/subspaces/keeper/common_test.go
+++ b/x/subspaces/keeper/common_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/stretchr/testify/suite"
@@ -26,6 +28,7 @@ type KeeperTestsuite struct {
 	legacyAminoCdc *codec.LegacyAmino
 	ctx            sdk.Context
 	k              keeper.Keeper
+	ak             authkeeper.AccountKeeper
 	paramsKeeper   paramskeeper.Keeper
 	storeKey       sdk.StoreKey
 }
@@ -36,8 +39,8 @@ func TestKeeperTestSuite(t *testing.T) {
 
 func (suite *KeeperTestsuite) SetupTest() {
 	// Define store keys
-	keys := sdk.NewMemoryStoreKeys(types.StoreKey, paramstypes.StoreKey)
-
+	keys := sdk.NewMemoryStoreKeys(types.StoreKey, paramstypes.StoreKey, authtypes.StoreKey)
+	tKeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
 	suite.storeKey = keys[types.StoreKey]
 
 	// Create an in-memory db
@@ -55,5 +58,15 @@ func (suite *KeeperTestsuite) SetupTest() {
 	suite.cdc, suite.legacyAminoCdc = app.MakeCodecs()
 
 	// Define keeper
-	suite.k = keeper.NewKeeper(suite.cdc, suite.storeKey)
+	suite.paramsKeeper = paramskeeper.NewKeeper(
+		suite.cdc, suite.legacyAminoCdc, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey],
+	)
+	suite.ak = authkeeper.NewAccountKeeper(
+		suite.cdc,
+		keys[authtypes.StoreKey],
+		suite.paramsKeeper.Subspace(authtypes.ModuleName),
+		authtypes.ProtoBaseAccount,
+		app.GetMaccPerms(),
+	)
+	suite.k = keeper.NewKeeper(suite.cdc, suite.storeKey, suite.ak)
 }

--- a/x/subspaces/keeper/groups_test.go
+++ b/x/subspaces/keeper/groups_test.go
@@ -446,6 +446,8 @@ func (suite *KeeperTestsuite) TestKeeper_AddUserToGroup() {
 			check: func(ctx sdk.Context) {
 				isMember := suite.k.IsMemberOfGroup(ctx, 1, 1, "cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm")
 				suite.Require().True(isMember)
+				acc, _ := sdk.AccAddressFromBech32("cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm")
+				suite.Require().True(suite.ak.HasAccount(ctx, acc))
 			},
 		},
 	}

--- a/x/subspaces/keeper/invariants_test.go
+++ b/x/subspaces/keeper/invariants_test.go
@@ -627,7 +627,7 @@ func (suite *KeeperTestsuite) TestValidUserPermissionsInvariant() {
 					"Test section",
 				))
 
-				suite.k.SetUserPermissions(ctx, 1, 1, "", types.NewPermissions())
+				suite.k.SetUserPermissions(ctx, 1, 1, "cosmos1fz49f2njk28ue8geqm63g4zzsm97lahqa9vmwn", types.NewPermissions("invalid"))
 			},
 			expBroken: true,
 		},

--- a/x/subspaces/keeper/keeper.go
+++ b/x/subspaces/keeper/keeper.go
@@ -12,13 +12,15 @@ type Keeper struct {
 	storeKey sdk.StoreKey
 	cdc      codec.BinaryCodec
 	hooks    types.SubspacesHooks
+	ak       types.AccountKeeper
 }
 
 // NewKeeper creates new instances of the subspaces keeper
-func NewKeeper(cdc codec.BinaryCodec, storeKey sdk.StoreKey) Keeper {
+func NewKeeper(cdc codec.BinaryCodec, storeKey sdk.StoreKey, ak types.AccountKeeper) Keeper {
 	return Keeper{
 		storeKey: storeKey,
 		cdc:      cdc,
+		ak:       ak,
 	}
 }
 

--- a/x/subspaces/keeper/keeper_test.go
+++ b/x/subspaces/keeper/keeper_test.go
@@ -29,7 +29,7 @@ func TestKeeper_SetHooks(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			subspaceKeeper := keeper.NewKeeper(nil, nil)
+			subspaceKeeper := keeper.NewKeeper(nil, nil, nil)
 			k := subspaceKeeper.SetHooks(tc.hooks)
 
 			if tc.shouldErr {

--- a/x/subspaces/keeper/permissions_test.go
+++ b/x/subspaces/keeper/permissions_test.go
@@ -46,6 +46,8 @@ func (suite *KeeperTestsuite) TestKeeper_SetUserPermissions() {
 			check: func(ctx sdk.Context) {
 				permission := suite.k.GetUserPermissions(ctx, 1, 0, "cosmos1fz49f2njk28ue8geqm63g4zzsm97lahqa9vmwn")
 				suite.Require().Equal(types.NewPermissions(types.PermissionDeleteSubspace), permission)
+				acc, _ := sdk.AccAddressFromBech32("cosmos1fz49f2njk28ue8geqm63g4zzsm97lahqa9vmwn")
+				suite.Require().True(suite.ak.HasAccount(ctx, acc))
 			},
 		},
 	}

--- a/x/subspaces/legacy/v5/store.go
+++ b/x/subspaces/legacy/v5/store.go
@@ -13,11 +13,11 @@ import (
 // - create account for all the users inside groups if they don't have it;
 // - create account for all the users having permissions inside a subspace if they don't have it.
 func MigrateStore(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
-	migrateUserAccountInUserGroups(ctx, key, accountKeeper)
-	return migrateUserAccountInPermissions(ctx, key, accountKeeper)
+	migrateUserAccountsInUserGroups(ctx, key, accountKeeper)
+	return migrateUserAccountsInPermissions(ctx, key, accountKeeper)
 }
 
-func migrateUserAccountInUserGroups(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
+func migrateUserAccountsInUserGroups(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
 	groupsStore := prefix.NewStore(ctx.KVStore(key), types.GroupsMembersPrefix)
 	iterator := groupsStore.Iterator(nil, nil)
 	defer iterator.Close()
@@ -37,7 +37,7 @@ func migrateUserAccountInUserGroups(ctx sdk.Context, key sdk.StoreKey, accountKe
 	return nil
 }
 
-func migrateUserAccountInPermissions(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
+func migrateUserAccountsInPermissions(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
 	permissionsStore := prefix.NewStore(ctx.KVStore(key), types.UserPermissionsStorePrefix)
 	iterator := permissionsStore.Iterator(nil, nil)
 	defer iterator.Close()

--- a/x/subspaces/legacy/v5/store.go
+++ b/x/subspaces/legacy/v5/store.go
@@ -1,0 +1,58 @@
+package v4
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	"github.com/desmos-labs/desmos/v4/x/subspaces/types"
+)
+
+// MigrateStore migrates the store from version 4 to version 5.
+// The migration includes the following:
+//
+// - create account for all the users inside groups if they don't have it;
+// - create account for all the users having permissions inside a subspace if they don't have it.
+func MigrateStore(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
+	migrateUserAccountInUserGroups(ctx, key, accountKeeper)
+	return migrateUserAccountInPermissions(ctx, key, accountKeeper)
+}
+
+func migrateUserAccountInUserGroups(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
+	groupsStore := prefix.NewStore(ctx.KVStore(key), types.GroupsMembersPrefix)
+	iterator := groupsStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		_, _, user := types.SplitGroupMemberStoreKey(append(types.GroupsMembersPrefix, iterator.Key()...))
+		userAcc, err := sdk.AccAddressFromBech32(user)
+		if err != nil {
+			return err
+		}
+
+		accExists := accountKeeper.HasAccount(ctx, userAcc)
+		if !accExists {
+			accountKeeper.SetAccount(ctx, accountKeeper.NewAccountWithAddress(ctx, userAcc))
+		}
+	}
+	return nil
+}
+
+func migrateUserAccountInPermissions(ctx sdk.Context, key sdk.StoreKey, accountKeeper authkeeper.AccountKeeper) error {
+	permissionsStore := prefix.NewStore(ctx.KVStore(key), types.UserPermissionsStorePrefix)
+	iterator := permissionsStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		_, _, user := types.SplitUserAddressPermissionKey(append(types.UserPermissionsStorePrefix, iterator.Key()...))
+		userAcc, err := sdk.AccAddressFromBech32(user)
+		if err != nil {
+			return err
+		}
+
+		accExists := accountKeeper.HasAccount(ctx, userAcc)
+		if !accExists {
+			accountKeeper.SetAccount(ctx, accountKeeper.NewAccountWithAddress(ctx, userAcc))
+		}
+	}
+	return nil
+}

--- a/x/subspaces/legacy/v5/store_test.go
+++ b/x/subspaces/legacy/v5/store_test.go
@@ -1,0 +1,93 @@
+package v4_test
+
+import (
+	"testing"
+
+	v5 "github.com/desmos-labs/desmos/v4/x/subspaces/legacy/v5"
+	"github.com/desmos-labs/desmos/v4/x/subspaces/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/desmos-labs/desmos/v4/app"
+	"github.com/desmos-labs/desmos/v4/testutil/storetesting"
+)
+
+func TestMigrateStore(t *testing.T) {
+	cdc, legacyAminoCdc := app.MakeCodecs()
+
+	// Build all the necessary keys
+	keys := sdk.NewKVStoreKeys(authtypes.StoreKey, paramstypes.StoreKey, types.StoreKey)
+	tKeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
+	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
+
+	// Build the params keeper
+	paramsKeeper := paramskeeper.NewKeeper(
+		cdc, legacyAminoCdc, keys[paramstypes.StoreKey], tKeys[paramstypes.TStoreKey],
+	)
+	// Build the auth keeper
+	authKeeper := authkeeper.NewAccountKeeper(
+		cdc,
+		keys[authtypes.StoreKey],
+		paramsKeeper.Subspace(authtypes.ModuleName),
+		authtypes.ProtoBaseAccount,
+		app.GetMaccPerms(),
+	)
+
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		shouldErr bool
+		check     func(ctx sdk.Context)
+	}{
+		{
+			name: "accounts of all the users inside groups are created properly",
+			store: func(ctx sdk.Context) {
+				store := ctx.KVStore(keys[types.StoreKey])
+				store.Set(types.GroupMemberStoreKey(1, 1, "cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm"), []byte{0x01})
+			},
+			check: func(ctx sdk.Context) {
+				userAcc, _ := sdk.AccAddressFromBech32("cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm")
+				require.True(t, authKeeper.HasAccount(ctx, userAcc))
+			},
+		},
+		{
+			name: "accounts of all the users having subspace permissions are created properly",
+			store: func(ctx sdk.Context) {
+				store := ctx.KVStore(keys[types.StoreKey])
+				permission := types.NewUserPermission(1, 1, "cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm", types.NewPermissions("edit subspace"))
+				store.Set(types.UserPermissionStoreKey(1, 1, "cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm"), cdc.MustMarshal(&permission))
+			},
+			check: func(ctx sdk.Context) {
+				userAcc, _ := sdk.AccAddressFromBech32("cosmos1a0cj0j6ujn2xap8p40y6648d0w2npytw3xvenm")
+				require.True(t, authKeeper.HasAccount(ctx, userAcc))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := storetesting.BuildContext(keys, tKeys, memKeys)
+			if tc.store != nil {
+				tc.store(ctx)
+			}
+
+			err := v5.MigrateStore(ctx, keys[types.StoreKey], authKeeper)
+			if tc.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tc.check != nil {
+					tc.check(ctx)
+				}
+			}
+		})
+	}
+}

--- a/x/subspaces/types/expected_keepers.go
+++ b/x/subspaces/types/expected_keepers.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// DONTCOVER
+
+// AccountKeeper represents the expected keeper used to interact with x/auth
+type AccountKeeper interface {
+	HasAccount(ctx sdk.Context, addr sdk.AccAddress) bool
+	NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+	SetAccount(ctx sdk.Context, account authtypes.AccountI)
+}


### PR DESCRIPTION
## Description

This PR implements account creation when subspace `AddUserToUserGroup` and `SetUserPermissions` operations executed.
Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)