### PR TITLE
fix!: register MsgDeleteSubspace within Amino codec

### DIFF
--- a/.changeset/entries/910f8ded0fd0361d9d354227986d2a425ee4ec342e8747345ea97261d383f4bf.yaml
+++ b/.changeset/entries/910f8ded0fd0361d9d354227986d2a425ee4ec342e8747345ea97261d383f4bf.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/subspaces
+pull_request: 1074
+description: Added missing MsgDeleteSubspace Amino registration
+backward_compatible: false
+date: 2023-01-27T17:11:47.443053713Z

--- a/x/subspaces/types/codec.go
+++ b/x/subspaces/types/codec.go
@@ -12,13 +12,14 @@ import (
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgCreateSubspace{}, "desmos/MsgCreateSubspace", nil)
 	cdc.RegisterConcrete(&MsgEditSubspace{}, "desmos/MsgEditSubspace", nil)
-	cdc.RegisterConcrete(&MsgCreateUserGroup{}, "desmos/MsgCreateUserGroup", nil)
+	cdc.RegisterConcrete(&MsgDeleteSubspace{}, "desmos/MsgDeleteSubspace", nil)
 
 	cdc.RegisterConcrete(&MsgCreateSection{}, "desmos/MsgCreateSection", nil)
 	cdc.RegisterConcrete(&MsgEditSection{}, "desmos/MsgEditSection", nil)
 	cdc.RegisterConcrete(&MsgMoveSection{}, "desmos/MsgMoveSection", nil)
 	cdc.RegisterConcrete(&MsgDeleteSection{}, "desmos/MsgDeleteSection", nil)
 
+	cdc.RegisterConcrete(&MsgCreateUserGroup{}, "desmos/MsgCreateUserGroup", nil)
 	cdc.RegisterConcrete(&MsgEditUserGroup{}, "desmos/MsgEditUserGroup", nil)
 	cdc.RegisterConcrete(&MsgMoveUserGroup{}, "desmos/MsgMoveUserGroup", nil)
 	cdc.RegisterConcrete(&MsgSetUserGroupPermissions{}, "desmos/MsgSetUserGroupPermissions", nil)

--- a/x/subspaces/types/msgs_test.go
+++ b/x/subspaces/types/msgs_test.go
@@ -215,7 +215,7 @@ func TestMsgDeleteSubspace_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgDeleteSubspace_GetSignBytes(t *testing.T) {
-	expected := `{"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}`
+	expected := `{"type":"desmos/MsgDeleteSubspace","value":{"signer":"cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgDeleteSubspace.GetSignBytes()))
 }
 


### PR DESCRIPTION
## Description

This PR adds the registration of the `MsgDeleteSubspace` within the module's Amino codec.

#### Note
Once this is merged, this change should also be backported to `4.8.x` in order to release a new version that fixes this in both the testnet and the mainnet.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)