### PR TITLE
docs(adr): ADR-20: Post ownership transfer

### DIFF
--- a/docs/architecture/adr-020-post-ownership-change.md
+++ b/docs/architecture/adr-020-post-ownership-change.md
@@ -1,0 +1,83 @@
+# ADR 020: Post ownership transfer
+
+## Changelog
+- April 21th, 2023: First draft;
+
+## Status
+
+Proposed
+
+## Abstract
+
+This ADR introduces a new feature that enables users to transfer post ownership to another person.
+
+## Context
+
+Desmos is a social network protocol that allows users to create, share, and engage with content on a decentralized platform. As of now, Desmos does not provide a feature that allows users to transfer the ownership of their posts to other users. This has caused inconvenience for users who wish to transfer ownership of their posts, as they have to create new posts and lose the engagement history and feedback of the original post. Therefore, the introduction of the new feature that enables users to transfer post ownership to another person aims to address this issue and provide users with more control over their content. The proposed feature is expected to improve user experience and enhance the functionality of the Desmos protocol.
+
+## Decision
+
+We will add an __owner__ field to the post structure and implement a new handler that allows users to transfer post ownership to another person. The upcoming changes are as follows:
+
+### Type
+
+```proto
+message Post {
+  uint64 subspace_id = 1;
+  uint32 section_id = 2;
+  
+  ...skip
+
+  google.protobuf.Timestamp last_edited_date = 13;
+  
+  // Owner of the post
+  string owner = 14;
+}
+```
+
+### `Msg` Service
+
+```proto
+service Msg {
+    // ChangePostOwner allows users to transfer the ownership of a post to another person
+    rpc ChangePostOwner(MsgChangePostOwner) returns (MsgChangePostOwnerResponse);
+}
+
+// MsgChangePostOwner move a post to another subspace
+message MsgChangePostOwner {
+    // Id of the subspace
+    uint64 subspace_id = 1;
+    
+    // Id of the post
+    uint64 post_id = 2;
+
+    // Address of the new post owner
+    string new_owner = 3;
+    
+    // Address of the current post owner
+    string owner = 5;
+}
+// MsgChangePostOwnerResponse defines the Msg/MsgChangePostOwner response type
+message MsgChangePostOwnerResponse {}
+```
+
+## Consequences
+
+### Backwards Compatibility
+
+The solution outlined above is **not** backwards compatible and will require a migration script to update all existing posts to the new version. This script will handle the following tasks:
+- migrate all posts to have a new __owner__ field.
+
+### Positive
+
+- Enable users to transfer the ownership of the post
+
+### Negative
+
+(none known)
+
+### Neutral
+
+(none known)
+
+## References

--- a/docs/architecture/adr-020-post-ownership-change.md
+++ b/docs/architecture/adr-020-post-ownership-change.md
@@ -5,7 +5,7 @@
 
 ## Status
 
-Proposed
+Accepted Not Implemented
 
 ## Abstract
 


### PR DESCRIPTION
## Description

This PR represents the ADR for a new feature that will allow users to transfer the ownership of their posts to another user.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)