### PR TITLE
fix: refuse to move default user group

### DIFF
--- a/.changeset/entries/3a100bf361284b082e267a3ae553e65c258a5c083b3d4a706137038eab1f1b51.yaml
+++ b/.changeset/entries/3a100bf361284b082e267a3ae553e65c258a5c083b3d4a706137038eab1f1b51.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: x/subspaces
+pull_request: 1139
+description: Refuse to move default user group
+backward_compatible: true
+date: 2023-05-11T10:15:50.6146351Z

--- a/x/reactions/simulation/operations_reactions.go
+++ b/x/reactions/simulation/operations_reactions.go
@@ -135,6 +135,12 @@ func randomAddReactionFields(
 		return
 	}
 
+	if k.HasReacted(ctx, subspaceID, postID, acc.Address.String(), value) {
+		// Skip because user has the same reaction to the post
+		skip = true
+		return
+	}
+
 	user = *acc
 
 	// Generate a random reaction

--- a/x/subspaces/keeper/migrations.go
+++ b/x/subspaces/keeper/migrations.go
@@ -8,6 +8,7 @@ import (
 	v3 "github.com/desmos-labs/desmos/v4/x/subspaces/legacy/v3"
 	v4 "github.com/desmos-labs/desmos/v4/x/subspaces/legacy/v4"
 	v5 "github.com/desmos-labs/desmos/v4/x/subspaces/legacy/v5"
+	v6 "github.com/desmos-labs/desmos/v4/x/subspaces/legacy/v6"
 	"github.com/desmos-labs/desmos/v4/x/subspaces/types"
 )
 
@@ -47,4 +48,9 @@ func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 // Migrate4to5 migrates from version 4 to 5.
 func (m Migrator) Migrate4to5(ctx sdk.Context) error {
 	return v5.MigrateStore(ctx, m.keeper.storeKey, m.keeper.cdc, m.ak)
+}
+
+// Migrate5to6 migrates from version 5 to 6.
+func (m Migrator) Migrate5to6(ctx sdk.Context) error {
+	return v6.MigrateStore(ctx, m.keeper.storeKey, m.keeper.cdc)
 }

--- a/x/subspaces/legacy/v6/store.go
+++ b/x/subspaces/legacy/v6/store.go
@@ -1,0 +1,56 @@
+package v5
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/desmos-labs/desmos/v4/x/subspaces/types"
+)
+
+// MigrateStore migrates the store from version 5 to version 6.
+func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) error {
+	return moveDefaultUserGroupToRootSection(ctx, storeKey, cdc)
+}
+
+func moveDefaultUserGroupToRootSection(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) error {
+	store := ctx.KVStore(storeKey)
+	groupsStore := prefix.NewStore(store, types.GroupsPrefix)
+	iterator := groupsStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var oldGroup types.UserGroup
+		cdc.MustUnmarshal(iterator.Value(), &oldGroup)
+
+		if oldGroup.ID != types.DefaultGroupID {
+			// Skip because the group is not default
+			continue
+		}
+
+		if oldGroup.SectionID == types.RootSectionID {
+			// Skip because the default group has not been moved
+			continue
+		}
+
+		// Delete moved old default group key
+		store.Delete(types.GroupStoreKey(oldGroup.SubspaceID, oldGroup.SectionID, oldGroup.ID))
+
+		// Save new default group key
+		newGroup := types.NewUserGroup(
+			oldGroup.SubspaceID,
+			types.RootSectionID,
+			types.DefaultGroupID,
+			oldGroup.Name,
+			oldGroup.Description,
+			oldGroup.Permissions,
+		)
+
+		store.Set(
+			types.GroupStoreKey(newGroup.SubspaceID, newGroup.SectionID, newGroup.ID),
+			cdc.MustMarshal(&newGroup),
+		)
+	}
+	return nil
+}

--- a/x/subspaces/legacy/v6/store_test.go
+++ b/x/subspaces/legacy/v6/store_test.go
@@ -1,0 +1,142 @@
+package v5_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/desmos-labs/desmos/v4/app"
+	"github.com/desmos-labs/desmos/v4/testutil/storetesting"
+	v6 "github.com/desmos-labs/desmos/v4/x/subspaces/legacy/v6"
+	"github.com/desmos-labs/desmos/v4/x/subspaces/types"
+)
+
+func TestMigrateStore(t *testing.T) {
+	cdc, _ := app.MakeCodecs()
+
+	// Build all the necessary keys
+	keys := sdk.NewKVStoreKeys(types.StoreKey)
+
+	testCases := []struct {
+		name      string
+		store     func(ctx sdk.Context)
+		shouldErr bool
+		check     func(ctx sdk.Context)
+	}{
+		{
+			name: "non default group is skipped properly",
+			store: func(ctx sdk.Context) {
+				oldGroup := types.NewUserGroup(
+					1,
+					1,
+					1,
+					"default group",
+					"description",
+					types.NewPermissions(types.NewPermission(types.PermissionEverything)),
+				)
+				ctx.KVStore(keys[types.StoreKey]).Set(
+					types.GroupStoreKey(1, oldGroup.SectionID, oldGroup.ID),
+					cdc.MustMarshal(&oldGroup),
+				)
+			},
+			check: func(ctx sdk.Context) {
+				var newGroup types.UserGroup
+				cdc.MustUnmarshal(ctx.KVStore(keys[types.StoreKey]).
+					Get(types.GroupStoreKey(1, 1, 1)), &newGroup)
+
+				require.Equal(t, types.NewUserGroup(
+					1,
+					1,
+					1,
+					"default group",
+					"description",
+					types.NewPermissions(types.NewPermission(types.PermissionEverything)),
+				), newGroup)
+			},
+		},
+		{
+			name: "non-moved default group is migrated properly",
+			store: func(ctx sdk.Context) {
+				oldGroup := types.NewUserGroup(
+					1,
+					types.RootSectionID,
+					types.DefaultGroupID,
+					"default group",
+					"description",
+					types.NewPermissions(types.NewPermission(types.PermissionEverything)),
+				)
+				ctx.KVStore(keys[types.StoreKey]).Set(
+					types.GroupStoreKey(1, oldGroup.SectionID, oldGroup.ID),
+					cdc.MustMarshal(&oldGroup),
+				)
+			},
+			check: func(ctx sdk.Context) {
+				var newGroup types.UserGroup
+				cdc.MustUnmarshal(ctx.KVStore(keys[types.StoreKey]).
+					Get(types.GroupStoreKey(1, types.RootSectionID, types.DefaultGroupID)), &newGroup)
+
+				require.Equal(t, types.NewUserGroup(
+					1,
+					types.RootSectionID,
+					types.DefaultGroupID,
+					"default group",
+					"description",
+					types.NewPermissions(types.NewPermission(types.PermissionEverything)),
+				), newGroup)
+			},
+		},
+		{
+			name: "moved default group is migrated properly",
+			store: func(ctx sdk.Context) {
+				oldGroup := types.NewUserGroup(
+					1,
+					1,
+					types.DefaultGroupID,
+					"default group",
+					"description",
+					types.NewPermissions(types.NewPermission(types.PermissionEverything)),
+				)
+				ctx.KVStore(keys[types.StoreKey]).Set(
+					types.GroupStoreKey(1, oldGroup.SectionID, oldGroup.ID),
+					cdc.MustMarshal(&oldGroup),
+				)
+			},
+			check: func(ctx sdk.Context) {
+				var newGroup types.UserGroup
+				cdc.MustUnmarshal(ctx.KVStore(keys[types.StoreKey]).
+					Get(types.GroupStoreKey(1, types.RootSectionID, types.DefaultGroupID)), &newGroup)
+
+				require.Equal(t, types.NewUserGroup(
+					1,
+					types.RootSectionID,
+					types.DefaultGroupID,
+					"default group",
+					"description",
+					types.NewPermissions(types.NewPermission(types.PermissionEverything)),
+				), newGroup)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := storetesting.BuildContext(keys, nil, nil)
+			if tc.store != nil {
+				tc.store(ctx)
+			}
+
+			err := v6.MigrateStore(ctx, keys[types.StoreKey], cdc)
+			if tc.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tc.check != nil {
+					tc.check(ctx)
+				}
+			}
+		})
+	}
+}

--- a/x/subspaces/module.go
+++ b/x/subspaces/module.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	consensusVersion = 5
+	consensusVersion = 6
 )
 
 // type check to ensure the interface is properly implemented
@@ -124,6 +124,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 		panic(err)
 	}
 	err = cfg.RegisterMigration(types.ModuleName, 4, m.Migrate4to5)
+	if err != nil {
+		panic(err)
+	}
+	err = cfg.RegisterMigration(types.ModuleName, 5, m.Migrate5to6)
 	if err != nil {
 		panic(err)
 	}

--- a/x/subspaces/simulation/operations_groups.go
+++ b/x/subspaces/simulation/operations_groups.go
@@ -199,6 +199,11 @@ func randomMoveUserGroupFields(
 	}
 	group := RandomGroup(r, groups)
 	groupID = group.ID
+	if groupID == 0 {
+		// Skip because default group can not be moved
+		skip = true
+		return
+	}
 
 	// Get a section
 	sections := k.GetSubspaceSections(ctx, subspaceID)

--- a/x/subspaces/types/models.go
+++ b/x/subspaces/types/models.go
@@ -136,6 +136,9 @@ func NewSubspaceUpdate(name, description, owner string) SubspaceUpdate {
 const (
 	// RootSectionID represents the id of the root section of each subspace
 	RootSectionID = 0
+
+	// DefaultGroupID represents the id of the default group of each subspace
+	DefaultGroupID = 0
 )
 
 // ParseSectionID parses the given value as a section id, returning an error if it's invalid

--- a/x/subspaces/types/msgs.go
+++ b/x/subspaces/types/msgs.go
@@ -537,6 +537,10 @@ func (msg MsgMoveUserGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid subspace id: %d", msg.SubspaceID)
 	}
 
+	if msg.GroupID == 0 {
+		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid group id: %d", msg.GroupID)
+	}
+
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address")

--- a/x/subspaces/types/msgs.go
+++ b/x/subspaces/types/msgs.go
@@ -635,7 +635,7 @@ func (msg MsgDeleteUserGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid subspace id: %d", msg.SubspaceID)
 	}
 
-	if msg.GroupID == 0 {
+	if msg.GroupID == DefaultGroupID {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid group id: %d", msg.GroupID)
 	}
 
@@ -687,7 +687,7 @@ func (msg MsgAddUserToUserGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid subspace id: %d", msg.SubspaceID)
 	}
 
-	if msg.GroupID == 0 {
+	if msg.GroupID == DefaultGroupID {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid group id: %d", msg.GroupID)
 	}
 
@@ -744,7 +744,7 @@ func (msg MsgRemoveUserFromUserGroup) ValidateBasic() error {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid subspace id: %d", msg.SubspaceID)
 	}
 
-	if msg.GroupID == 0 {
+	if msg.GroupID == DefaultGroupID {
 		return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid group id: %d", msg.GroupID)
 	}
 

--- a/x/subspaces/types/msgs_test.go
+++ b/x/subspaces/types/msgs_test.go
@@ -785,6 +785,16 @@ func TestMsgMoveUserGroup_ValidateBasic(t *testing.T) {
 			shouldErr: true,
 		},
 		{
+			name: "invalid group id returns error",
+			msg: types.NewMsgMoveUserGroup(
+				0,
+				0,
+				msgMoveUserGroup.NewSectionID,
+				msgMoveUserGroup.Signer,
+			),
+			shouldErr: true,
+		},
+		{
 			name: "invalid creator returns error",
 			msg: types.NewMsgMoveUserGroup(
 				msgMoveUserGroup.SubspaceID,


### PR DESCRIPTION
## Description

Closes: #XXXX

This PR fixes the bug that we allow to move the default group to other section, it causes `test-sim-import-export` error happens the following steps:

1. Create a new subspace and `SaveSubspace` creates a default user group as well
2. Create a new section with id `1`, then default group key become `subspace-1 section-1 group-0`
3. Move default group to new section `1`
4. Export genesis then import it, the new app state will differ with the original one since `SaveSubspace` creates default group again on the key `subspace-1 section-0 group-0`

As every one are the members inside default group, we should refuse to move group to other sections.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [x] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)