### PR TITLE
fix: empty address error when using sign command

### DIFF
--- a/app/desmos/cmd/sign/sign.go
+++ b/app/desmos/cmd/sign/sign.go
@@ -132,11 +132,17 @@ func signAmino(clientCtx client.Context, txFactory tx.Factory, key *keyring.Reco
 	}
 
 	// Encode the transaction
+	address, err := key.GetAddress()
+	if err != nil {
+		return
+	}
+
 	signMode := signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON
 	signerData := authsigning.SignerData{
 		ChainID:       txFactory.ChainID(),
 		AccountNumber: txFactory.AccountNumber(),
 		Sequence:      txFactory.Sequence(),
+		Address:       address.String(),
 	}
 	valueBz, err = clientCtx.TxConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
 	if err != nil {


### PR DESCRIPTION
## Description

This PR fixes the following error that existed when using the `desmos sign` command with a Ledger device after upgrading to Cosmos `v0.47.x`:

```
Error: got empty address in SIGN_MODE_LEGACY_AMINO_JSON handler: invalid request
```

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)