### PR TITLE
refactor: use `RegisterAminoMsg` to register Amino encodings

### DIFF
--- a/x/posts/types/codec.go
+++ b/x/posts/types/codec.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,21 +18,21 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&Poll{}, "desmos/Poll", nil)
 	cdc.RegisterConcrete(&Media{}, "desmos/Media", nil)
 
-	cdc.RegisterConcrete(&MsgCreatePost{}, "desmos/MsgCreatePost", nil)
-	cdc.RegisterConcrete(&MsgEditPost{}, "desmos/MsgEditPost", nil)
-	cdc.RegisterConcrete(&MsgAddPostAttachment{}, "desmos/MsgAddPostAttachment", nil)
-	cdc.RegisterConcrete(&MsgRemovePostAttachment{}, "desmos/MsgRemovePostAttachment", nil)
-	cdc.RegisterConcrete(&MsgDeletePost{}, "desmos/MsgDeletePost", nil)
-	cdc.RegisterConcrete(&MsgAnswerPoll{}, "desmos/MsgAnswerPoll", nil)
-	cdc.RegisterConcrete(&MsgMovePost{}, "desmos/MsgMovePost", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgCreatePost{}, "desmos/MsgCreatePost")
+	legacy.RegisterAminoMsg(cdc, &MsgEditPost{}, "desmos/MsgEditPost")
+	legacy.RegisterAminoMsg(cdc, &MsgAddPostAttachment{}, "desmos/MsgAddPostAttachment")
+	legacy.RegisterAminoMsg(cdc, &MsgRemovePostAttachment{}, "desmos/MsgRemovePostAttachment")
+	legacy.RegisterAminoMsg(cdc, &MsgDeletePost{}, "desmos/MsgDeletePost")
+	legacy.RegisterAminoMsg(cdc, &MsgAnswerPoll{}, "desmos/MsgAnswerPoll")
+	legacy.RegisterAminoMsg(cdc, &MsgMovePost{}, "desmos/MsgMovePost")
 
-	cdc.Amino.RegisterConcrete(&MsgRequestPostOwnerTransfer{}, "desmos/MsgRequestPostOwnerTransfer", nil)
-	cdc.Amino.RegisterConcrete(&MsgCancelPostOwnerTransferRequest{}, "desmos/MsgCancelPostOwnerTransferRequest", nil)
-	cdc.Amino.RegisterConcrete(&MsgAcceptPostOwnerTransferRequest{}, "desmos/MsgAcceptPostOwnerTransferRequest", nil)
-	cdc.Amino.RegisterConcrete(&MsgRefusePostOwnerTransferRequest{}, "desmos/MsgRefusePostOwnerTransferRequest", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgRequestPostOwnerTransfer{}, "desmos/MsgRequestPostOwnerTransfer")
+	legacy.RegisterAminoMsg(cdc, &MsgCancelPostOwnerTransferRequest{}, "desmos/MsgCancelPostOwnerTransferRequest")
+	legacy.RegisterAminoMsg(cdc, &MsgAcceptPostOwnerTransferRequest{}, "desmos/MsgAcceptPostOwnerTransferRequest")
+	legacy.RegisterAminoMsg(cdc, &MsgRefusePostOwnerTransferRequest{}, "desmos/MsgRefusePostOwnerTransferRequest")
 
 	cdc.RegisterConcrete(&Params{}, "desmos/x/posts/Params", nil)
-	cdc.RegisterConcrete(&MsgUpdateParams{}, "desmos/x/posts/MsgUpdateParams", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "desmos/x/posts/MsgUpdateParams")
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/posts/types/codec.go
+++ b/x/posts/types/codec.go
@@ -27,9 +27,9 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	legacy.RegisterAminoMsg(cdc, &MsgMovePost{}, "desmos/MsgMovePost")
 
 	legacy.RegisterAminoMsg(cdc, &MsgRequestPostOwnerTransfer{}, "desmos/MsgRequestPostOwnerTransfer")
-	legacy.RegisterAminoMsg(cdc, &MsgCancelPostOwnerTransferRequest{}, "desmos/MsgCancelPostOwnerTransferRequest")
-	legacy.RegisterAminoMsg(cdc, &MsgAcceptPostOwnerTransferRequest{}, "desmos/MsgAcceptPostOwnerTransferRequest")
-	legacy.RegisterAminoMsg(cdc, &MsgRefusePostOwnerTransferRequest{}, "desmos/MsgRefusePostOwnerTransferRequest")
+	legacy.RegisterAminoMsg(cdc, &MsgCancelPostOwnerTransferRequest{}, "desmos/MsgCancelPostOwnerTransfer")
+	legacy.RegisterAminoMsg(cdc, &MsgAcceptPostOwnerTransferRequest{}, "desmos/MsgAcceptPostOwnerTransfer")
+	legacy.RegisterAminoMsg(cdc, &MsgRefusePostOwnerTransferRequest{}, "desmos/MsgRefusePostOwnerTransfer")
 
 	cdc.RegisterConcrete(&Params{}, "desmos/x/posts/Params", nil)
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "desmos/x/posts/MsgUpdateParams")

--- a/x/posts/types/msgs_owner_transfer_test.go
+++ b/x/posts/types/msgs_owner_transfer_test.go
@@ -178,7 +178,7 @@ func TestMsgCancelPostOwnerTransferRequest_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgCancelPostOwnerTransferRequest_GetSignBytes(t *testing.T) {
-	expected := `{"type":"desmos/MsgCancelPostOwnerTransferRequest","value":{"post_id":"1","sender":"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg","subspace_id":"1"}}`
+	expected := `{"type":"desmos/MsgCancelPostOwnerTransfer","value":{"post_id":"1","sender":"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgCancelPostOwnerTransferRequest.GetSignBytes()))
 }
 
@@ -256,7 +256,7 @@ func TestMsgAcceptPostOwnerTransferRequest_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgAcceptPostOwnerTransferRequest_GetSignBytes(t *testing.T) {
-	expected := `{"type":"desmos/MsgAcceptPostOwnerTransferRequest","value":{"post_id":"1","receiver":"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg","subspace_id":"1"}}`
+	expected := `{"type":"desmos/MsgAcceptPostOwnerTransfer","value":{"post_id":"1","receiver":"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgAcceptPostOwnerTransferRequest.GetSignBytes()))
 }
 
@@ -334,7 +334,7 @@ func TestMsgRefusePostOwnerTransferRequest_ValidateBasic(t *testing.T) {
 }
 
 func TestMsgRefusePostOwnerTransferRequest_GetSignBytes(t *testing.T) {
-	expected := `{"type":"desmos/MsgRefusePostOwnerTransferRequest","value":{"post_id":"1","receiver":"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg","subspace_id":"1"}}`
+	expected := `{"type":"desmos/MsgRefusePostOwnerTransfer","value":{"post_id":"1","receiver":"cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg","subspace_id":"1"}}`
 	require.Equal(t, expected, string(msgRefusePostOwnerTransferRequest.GetSignBytes()))
 }
 

--- a/x/profiles/types/codec.go
+++ b/x/profiles/types/codec.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -19,18 +20,18 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&ethsecp256k1.PubKey{}, ethsecp256k1.PubKeyName, nil)
 	cdc.RegisterConcrete(&ethsecp256k1.PrivKey{}, ethsecp256k1.PrivKeyName, nil)
 
-	cdc.RegisterConcrete(&MsgSaveProfile{}, "desmos/MsgSaveProfile", nil)
-	cdc.RegisterConcrete(&MsgDeleteProfile{}, "desmos/MsgDeleteProfile", nil)
-	cdc.RegisterConcrete(&MsgRequestDTagTransfer{}, "desmos/MsgRequestDTagTransfer", nil)
-	cdc.RegisterConcrete(&MsgCancelDTagTransferRequest{}, "desmos/MsgCancelDTagTransferRequest", nil)
-	cdc.RegisterConcrete(&MsgAcceptDTagTransferRequest{}, "desmos/MsgAcceptDTagTransferRequest", nil)
-	cdc.RegisterConcrete(&MsgRefuseDTagTransferRequest{}, "desmos/MsgRefuseDTagTransferRequest", nil)
-	cdc.RegisterConcrete(&MsgLinkChainAccount{}, "desmos/MsgLinkChainAccount", nil)
-	cdc.RegisterConcrete(&MsgUnlinkChainAccount{}, "desmos/MsgUnlinkChainAccount", nil)
-	cdc.RegisterConcrete(&MsgSetDefaultExternalAddress{}, "desmos/MsgSetDefaultExternalAddress", nil)
-	cdc.RegisterConcrete(&MsgLinkApplication{}, "desmos/MsgLinkApplication", nil)
-	cdc.RegisterConcrete(&MsgUnlinkApplication{}, "desmos/MsgUnlinkApplication", nil)
-	cdc.RegisterConcrete(&MsgUpdateParams{}, "desmos/x/profiles/MsgUpdateParams", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgSaveProfile{}, "desmos/MsgSaveProfile")
+	legacy.RegisterAminoMsg(cdc, &MsgDeleteProfile{}, "desmos/MsgDeleteProfile")
+	legacy.RegisterAminoMsg(cdc, &MsgRequestDTagTransfer{}, "desmos/MsgRequestDTagTransfer")
+	legacy.RegisterAminoMsg(cdc, &MsgCancelDTagTransferRequest{}, "desmos/MsgCancelDTagTransferRequest")
+	legacy.RegisterAminoMsg(cdc, &MsgAcceptDTagTransferRequest{}, "desmos/MsgAcceptDTagTransferRequest")
+	legacy.RegisterAminoMsg(cdc, &MsgRefuseDTagTransferRequest{}, "desmos/MsgRefuseDTagTransferRequest")
+	legacy.RegisterAminoMsg(cdc, &MsgLinkChainAccount{}, "desmos/MsgLinkChainAccount")
+	legacy.RegisterAminoMsg(cdc, &MsgUnlinkChainAccount{}, "desmos/MsgUnlinkChainAccount")
+	legacy.RegisterAminoMsg(cdc, &MsgSetDefaultExternalAddress{}, "desmos/MsgSetDefaultExternalAddress")
+	legacy.RegisterAminoMsg(cdc, &MsgLinkApplication{}, "desmos/MsgLinkApplication")
+	legacy.RegisterAminoMsg(cdc, &MsgUnlinkApplication{}, "desmos/MsgUnlinkApplication")
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "desmos/x/profiles/MsgUpdateParams")
 
 	cdc.RegisterConcrete(&Params{}, "desmos/x/profiles/Params", nil)
 

--- a/x/reactions/types/codec.go
+++ b/x/reactions/types/codec.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,12 +15,12 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&RegisteredReactionValue{}, "desmos/RegisteredReactionValue", nil)
 	cdc.RegisterConcrete(&FreeTextValue{}, "desmos/FreeTextValue", nil)
 
-	cdc.RegisterConcrete(&MsgAddReaction{}, "desmos/MsgAddReaction", nil)
-	cdc.RegisterConcrete(&MsgRemoveReaction{}, "desmos/MsgRemoveReaction", nil)
-	cdc.RegisterConcrete(&MsgAddRegisteredReaction{}, "desmos/MsgAddRegisteredReaction", nil)
-	cdc.RegisterConcrete(&MsgEditRegisteredReaction{}, "desmos/MsgEditRegisteredReaction", nil)
-	cdc.RegisterConcrete(&MsgRemoveRegisteredReaction{}, "desmos/MsgRemoveRegisteredReaction", nil)
-	cdc.RegisterConcrete(&MsgSetReactionsParams{}, "desmos/MsgSetReactionsParams", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgAddReaction{}, "desmos/MsgAddReaction")
+	legacy.RegisterAminoMsg(cdc, &MsgRemoveReaction{}, "desmos/MsgRemoveReaction")
+	legacy.RegisterAminoMsg(cdc, &MsgAddRegisteredReaction{}, "desmos/MsgAddRegisteredReaction")
+	legacy.RegisterAminoMsg(cdc, &MsgEditRegisteredReaction{}, "desmos/MsgEditRegisteredReaction")
+	legacy.RegisterAminoMsg(cdc, &MsgRemoveRegisteredReaction{}, "desmos/MsgRemoveRegisteredReaction")
+	legacy.RegisterAminoMsg(cdc, &MsgSetReactionsParams{}, "desmos/MsgSetReactionsParams")
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/relationships/types/codec.go
+++ b/x/relationships/types/codec.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -10,10 +11,10 @@ import (
 )
 
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgCreateRelationship{}, "desmos/MsgCreateRelationship", nil)
-	cdc.RegisterConcrete(&MsgDeleteRelationship{}, "desmos/MsgDeleteRelationship", nil)
-	cdc.RegisterConcrete(&MsgBlockUser{}, "desmos/MsgBlockUser", nil)
-	cdc.RegisterConcrete(&MsgUnblockUser{}, "desmos/MsgUnblockUser", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgCreateRelationship{}, "desmos/MsgCreateRelationship")
+	legacy.RegisterAminoMsg(cdc, &MsgDeleteRelationship{}, "desmos/MsgDeleteRelationship")
+	legacy.RegisterAminoMsg(cdc, &MsgBlockUser{}, "desmos/MsgBlockUser")
+	legacy.RegisterAminoMsg(cdc, &MsgUnblockUser{}, "desmos/MsgUnblockUser")
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {

--- a/x/reports/types/codec.go
+++ b/x/reports/types/codec.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,12 +16,12 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&UserTarget{}, "desmos/UserTarget", nil)
 	cdc.RegisterConcrete(&PostTarget{}, "desmos/PostTarget", nil)
 
-	cdc.RegisterConcrete(&MsgCreateReport{}, "desmos/MsgCreateReport", nil)
-	cdc.RegisterConcrete(&MsgDeleteReport{}, "desmos/MsgDeleteReport", nil)
-	cdc.RegisterConcrete(&MsgSupportStandardReason{}, "desmos/MsgSupportStandardReason", nil)
-	cdc.RegisterConcrete(&MsgAddReason{}, "desmos/MsgAddReason", nil)
-	cdc.RegisterConcrete(&MsgRemoveReason{}, "desmos/MsgRemoveReason", nil)
-	cdc.RegisterConcrete(&MsgUpdateParams{}, "desmos/x/reports/MsgUpdateParams", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgCreateReport{}, "desmos/MsgCreateReport")
+	legacy.RegisterAminoMsg(cdc, &MsgDeleteReport{}, "desmos/MsgDeleteReport")
+	legacy.RegisterAminoMsg(cdc, &MsgSupportStandardReason{}, "desmos/MsgSupportStandardReason")
+	legacy.RegisterAminoMsg(cdc, &MsgAddReason{}, "desmos/MsgAddReason")
+	legacy.RegisterAminoMsg(cdc, &MsgRemoveReason{}, "desmos/MsgRemoveReason")
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "desmos/x/reports/MsgUpdateParams")
 
 	cdc.RegisterConcrete(&Params{}, "desmos/x/reports/Params", nil)
 }

--- a/x/subspaces/types/codec.go
+++ b/x/subspaces/types/codec.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -11,37 +12,37 @@ import (
 )
 
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgCreateSubspace{}, "desmos/MsgCreateSubspace", nil)
-	cdc.RegisterConcrete(&MsgEditSubspace{}, "desmos/MsgEditSubspace", nil)
-	cdc.RegisterConcrete(&MsgDeleteSubspace{}, "desmos/MsgDeleteSubspace", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgCreateSubspace{}, "desmos/MsgCreateSubspace")
+	legacy.RegisterAminoMsg(cdc, &MsgEditSubspace{}, "desmos/MsgEditSubspace")
+	legacy.RegisterAminoMsg(cdc, &MsgDeleteSubspace{}, "desmos/MsgDeleteSubspace")
 
-	cdc.RegisterConcrete(&MsgCreateSection{}, "desmos/MsgCreateSection", nil)
-	cdc.RegisterConcrete(&MsgEditSection{}, "desmos/MsgEditSection", nil)
-	cdc.RegisterConcrete(&MsgMoveSection{}, "desmos/MsgMoveSection", nil)
-	cdc.RegisterConcrete(&MsgDeleteSection{}, "desmos/MsgDeleteSection", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgCreateSection{}, "desmos/MsgCreateSection")
+	legacy.RegisterAminoMsg(cdc, &MsgEditSection{}, "desmos/MsgEditSection")
+	legacy.RegisterAminoMsg(cdc, &MsgMoveSection{}, "desmos/MsgMoveSection")
+	legacy.RegisterAminoMsg(cdc, &MsgDeleteSection{}, "desmos/MsgDeleteSection")
 
-	cdc.RegisterConcrete(&MsgCreateUserGroup{}, "desmos/MsgCreateUserGroup", nil)
-	cdc.RegisterConcrete(&MsgEditUserGroup{}, "desmos/MsgEditUserGroup", nil)
-	cdc.RegisterConcrete(&MsgMoveUserGroup{}, "desmos/MsgMoveUserGroup", nil)
-	cdc.RegisterConcrete(&MsgSetUserGroupPermissions{}, "desmos/MsgSetUserGroupPermissions", nil)
-	cdc.RegisterConcrete(&MsgDeleteUserGroup{}, "desmos/MsgDeleteUserGroup", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgCreateUserGroup{}, "desmos/MsgCreateUserGroup")
+	legacy.RegisterAminoMsg(cdc, &MsgEditUserGroup{}, "desmos/MsgEditUserGroup")
+	legacy.RegisterAminoMsg(cdc, &MsgMoveUserGroup{}, "desmos/MsgMoveUserGroup")
+	legacy.RegisterAminoMsg(cdc, &MsgSetUserGroupPermissions{}, "desmos/MsgSetUserGroupPermissions")
+	legacy.RegisterAminoMsg(cdc, &MsgDeleteUserGroup{}, "desmos/MsgDeleteUserGroup")
 
-	cdc.RegisterConcrete(&MsgAddUserToUserGroup{}, "desmos/MsgAddUserToUserGroup", nil)
-	cdc.RegisterConcrete(&MsgRemoveUserFromUserGroup{}, "desmos/MsgRemoveUserFromUserGroup", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgAddUserToUserGroup{}, "desmos/MsgAddUserToUserGroup")
+	legacy.RegisterAminoMsg(cdc, &MsgRemoveUserFromUserGroup{}, "desmos/MsgRemoveUserFromUserGroup")
 
-	cdc.RegisterConcrete(&MsgSetUserPermissions{}, "desmos/MsgSetUserPermissions", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgSetUserPermissions{}, "desmos/MsgSetUserPermissions")
 
-	cdc.RegisterConcrete(&MsgGrantTreasuryAuthorization{}, "desmos/MsgGrantTreasuryAuthorization", nil)
-	cdc.RegisterConcrete(&MsgRevokeTreasuryAuthorization{}, "desmos/MsgRevokeTreasuryAuthorization", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgGrantTreasuryAuthorization{}, "desmos/MsgGrantTreasuryAuthorization")
+	legacy.RegisterAminoMsg(cdc, &MsgRevokeTreasuryAuthorization{}, "desmos/MsgRevokeTreasuryAuthorization")
 
-	cdc.RegisterConcrete(&MsgGrantAllowance{}, "desmos/MsgGrantAllowance", nil)
-	cdc.RegisterConcrete(&MsgRevokeAllowance{}, "desmos/MsgRevokeAllowance", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgGrantAllowance{}, "desmos/MsgGrantAllowance")
+	legacy.RegisterAminoMsg(cdc, &MsgRevokeAllowance{}, "desmos/MsgRevokeAllowance")
 
 	cdc.RegisterInterface((*Grantee)(nil), nil)
 	cdc.RegisterConcrete(&UserGrantee{}, "desmos/UserGrantee", nil)
 	cdc.RegisterConcrete(&GroupGrantee{}, "desmos/GroupGrantee", nil)
 
-	cdc.RegisterConcrete(&MsgUpdateSubspaceFeeTokens{}, "desmos/MsgUpdateSubspaceFeeTokens", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgUpdateSubspaceFeeTokens{}, "desmos/MsgUpdateSubspaceFeeTokens")
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {


### PR DESCRIPTION
## Description

This PR replaces legacy amino registration of msgs into `RegisterAminoMsg` in order to avoid the bug that a registered Msg name that is too long when signing on ledger Nano device. See:
https://github.com/cosmos/cosmos-sdk/issues/10870

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)