### PR TITLE
docs: fix test statesync docs

### DIFF
--- a/docs/docs/05-testnet/04-join-public/04-state-sync.md
+++ b/docs/docs/05-testnet/04-join-public/04-state-sync.md
@@ -22,15 +22,15 @@ under the `statesync` section:
 3. Get a trusted chain height, and the associated block hash. To do this, you will have to:
     - Get the current chain height by running:
        ```bash
-       curl -s curl -s <rpc-address>/commit | jq "{height: .result.signed_header.header.height}"
+       curl -s <rpc-address>/commit | jq "{height: .result.signed_header.header.height}"
        ```
     - Once you have the current chain height, get a height that is a little lower (200 blocks) than the current one.  
       To do this you can execute:
        ```bash
-       curl -s curl -s <rpc-address>/commit?height=<your-height> | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
+       curl -s <rpc-address>/commit?height=<your-height> | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
  
        # Example
-       # curl -s curl -s <rpc-address>/commit?height=100000 | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
+       # curl -s <rpc-address>/commit?height=100000 | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
        ```
       
 4. Now that you have a trusted height and block hash, use those values as the `trust_height` and `trust_hash` values. 


### PR DESCRIPTION
## Description

Closes: #XXXX

This PR fix the testnet statsync docs.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)