### PR TITLE
feat: add v5.3.0 upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -3,10 +3,12 @@ package app
 import (
 	v500 "github.com/desmos-labs/desmos/v5/app/upgrades/v500"
 	v520 "github.com/desmos-labs/desmos/v5/app/upgrades/v520"
+	v530 "github.com/desmos-labs/desmos/v5/app/upgrades/v530"
 )
 
 // registerUpgradeHandlers registers all the upgrade handlers that are supported by the app
 func (app *DesmosApp) registerUpgradeHandlers() {
 	app.registerUpgrade(v500.NewUpgrade(app.ModuleManager, app.Configurator(), app.ParamsKeeper, app.ConsensusParamsKeeper))
 	app.registerUpgrade(v520.NewUpgrade(app.ModuleManager, app.Configurator(), app.ParamsKeeper, app.ConsensusParamsKeeper))
+	app.registerUpgrade(v530.NewUpgrade(app.ModuleManager, app.Configurator(), app.StakingKeeper))
 }

--- a/app/upgrades/v530/upgrade.go
+++ b/app/upgrades/v530/upgrade.go
@@ -1,0 +1,76 @@
+package v530
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/desmos-labs/desmos/v5/app/upgrades"
+)
+
+var (
+	_ upgrades.Upgrade = &Upgrade{}
+)
+
+// Upgrade represents the v5.3.0 upgrade
+type Upgrade struct {
+	mm           *module.Manager
+	configurator module.Configurator
+
+	sk *stakingkeeper.Keeper
+}
+
+// NewUpgrade returns a new Upgrade instance
+func NewUpgrade(mm *module.Manager, configurator module.Configurator, sk *stakingkeeper.Keeper) *Upgrade {
+	return &Upgrade{
+		mm:           mm,
+		configurator: configurator,
+		sk:           sk,
+	}
+}
+
+// Name implements upgrades.Upgrade
+func (u *Upgrade) Name() string {
+	return "v5.3.0"
+}
+
+// Handler implements upgrades.Upgrade
+func (u *Upgrade) Handler() upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Inside Desmos v5 we added the support for on-chain minimum validator commission.
+		// However, even if a proposal was submitted on-chain for this upgrade, the validators have not updated properly.
+		// This is due to this issue: https://github.com/cosmos/cosmos-sdk/issues/10540#issuecomment-1155390615.
+		//
+		// To fix this, we are going to run through all validators and make sure that they have their on-chain
+		// commission properly set based on the current on-chain minimum value that might have been set by the
+		// governance through a param change proposal.
+
+		minCommission := u.sk.GetParams(ctx).MinCommissionRate
+		u.sk.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+			validator, ok := val.(stakingtypes.Validator)
+			if !ok {
+				return false
+			}
+
+			// Make sure the commission rate is at least minCommission.
+			// Otherwise, set it to be that minimum
+			if validator.Commission.Rate.LT(minCommission) {
+				validator.Commission.Rate = minCommission
+				u.sk.SetValidator(ctx, validator)
+			}
+
+			return false
+		})
+
+		// After properly setting all the validator commissions, we can proceed with the normal migration
+		return u.mm.RunMigrations(ctx, u.configurator, fromVM)
+	}
+}
+
+// StoreUpgrades implements upgrades.Upgrade
+func (u *Upgrade) StoreUpgrades() *storetypes.StoreUpgrades {
+	return &storetypes.StoreUpgrades{}
+}


### PR DESCRIPTION
## Description

This PR adds the `v5.3.0` upgrade handler that also takes care of setting all validator's commission rate to the on-chain minimum, if it's lower than that.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)