### PR TITLE
fix: register missing stargate queries for contract

### DIFF
--- a/.changeset/entries/43992e9f7a2a6ed33633e7cda8d69e2c0fb029abb0f90d99203f0718ae6ed613.yaml
+++ b/.changeset/entries/43992e9f7a2a6ed33633e7cda8d69e2c0fb029abb0f90d99203f0718ae6ed613.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: other
+pull_request: 1218
+description: Register missing stargate queries
+backward_compatible: true
+date: 2023-08-24T13:06:06.678988667Z

--- a/app/wasm_config.go
+++ b/app/wasm_config.go
@@ -33,6 +33,8 @@ import (
 	subspacestypes "github.com/desmos-labs/desmos/v6/x/subspaces/types"
 	subspaceswasm "github.com/desmos-labs/desmos/v6/x/subspaces/wasm"
 
+	tokenfactorytypes "github.com/desmos-labs/desmos/v6/x/tokenfactory/types"
+
 	desmoswasmtypes "github.com/desmos-labs/desmos/v6/x/wasm/types"
 )
 
@@ -121,12 +123,13 @@ func GetStargateAcceptedQueries() wasmkeeper.AcceptedStargateQueries {
 		"/desmos.subspaces.v3.Query/GroupAllowances":  &subspacestypes.QueryGroupAllowancesResponse{},
 
 		// Register x/posts queries
-		"/desmos.posts.v3.Query/SubspacePosts":   &poststypes.QuerySubspacePostsResponse{},
-		"/desmos.posts.v3.Query/SectionPosts":    &poststypes.QuerySectionPostsResponse{},
-		"/desmos.posts.v3.Query/Post":            &poststypes.QueryPostResponse{},
-		"/desmos.posts.v3.Query/PostAttachments": &poststypes.QueryPostAttachmentsResponse{},
-		"/desmos.posts.v3.Query/PollAnswers":     &poststypes.QueryPollAnswersResponse{},
-		"/desmos.posts.v3.Query/Params":          &poststypes.QueryParamsResponse{},
+		"/desmos.posts.v3.Query/SubspacePosts":                          &poststypes.QuerySubspacePostsResponse{},
+		"/desmos.posts.v3.Query/SectionPosts":                           &poststypes.QuerySectionPostsResponse{},
+		"/desmos.posts.v3.Query/Post":                                   &poststypes.QueryPostResponse{},
+		"/desmos.posts.v3.Query/PostAttachments":                        &poststypes.QueryPostAttachmentsResponse{},
+		"/desmos.posts.v3.Query/PollAnswers":                            &poststypes.QueryPollAnswersResponse{},
+		"/desmos.posts.v3.Query/Params":                                 &poststypes.QueryParamsResponse{},
+		"/desmos.posts.v3.Query/QueryIncomingPostOwnerTransferRequests": &poststypes.QueryIncomingPostOwnerTransferRequestsResponse{},
 
 		// Register x/reports queries
 		"/desmos.reports.v1.Query/Reports": &reportstypes.QueryReportsResponse{},
@@ -141,6 +144,10 @@ func GetStargateAcceptedQueries() wasmkeeper.AcceptedStargateQueries {
 		"/desmos.reactions.v1.Query/RegisteredReactions": &reactionstypes.QueryRegisteredReactionsResponse{},
 		"/desmos.reactions.v1.Query/RegisteredReaction":  &reactionstypes.QueryRegisteredReactionResponse{},
 		"/desmos.reactions.v1.Query/ReactionsParams":     &reactionstypes.QueryReactionsParamsResponse{},
+
+		// Register x/tokenfactory queries
+		"/desmos.tokenfactory.v1.Query/Params":         &tokenfactorytypes.QueryParamsResponse{},
+		"/desmos.tokenfactory.v1.Query/SubspaceDenoms": &tokenfactorytypes.QuerySubspaceDenomsResponse{},
 	}
 }
 


### PR DESCRIPTION
## Description

Closes: #XXXX
This PR registers missing stargate queries for contract.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)