### PR TITLE
refactor: improve posts keeper input/output consistency

### DIFF
--- a/.changeset/entries/7abfad6cf351c8e8f5f63d0fa55e57c0a1752f6ee4b6cf234229f640b8b26134.yaml
+++ b/.changeset/entries/7abfad6cf351c8e8f5f63d0fa55e57c0a1752f6ee4b6cf234229f640b8b26134.yaml
@@ -1,0 +1,6 @@
+type: refactor
+module: x/posts
+pull_request: 1225
+description: Improve posts keeper input and output consistency
+backward_compatible: true
+date: 2023-08-31T07:26:01.660422652Z

--- a/app/app.go
+++ b/app/app.go
@@ -392,7 +392,7 @@ func NewDesmosApp(
 		app.ProfilesKeeper,
 		*app.SubspacesKeeper,
 		app.RelationshipsKeeper,
-		*app.PostsKeeper,
+		app.PostsKeeper,
 		app.ReportsKeeper,
 		app.ReactionsKeeper,
 	)

--- a/app/app_config.go
+++ b/app/app_config.go
@@ -120,7 +120,7 @@ func GetWasmOpts(
 	profilesKeeper *profileskeeper.Keeper,
 	subspacesKeeper subspaceskeeper.Keeper,
 	relationshipsKeeper relationshipskeeper.Keeper,
-	postsKeeper postskeeper.Keeper,
+	postsKeeper *postskeeper.Keeper,
 	reportsKeeper reportskeeper.Keeper,
 	reactionsKeeper reactionskeeper.Keeper,
 ) []wasmkeeper.Option {

--- a/app/wasm_config.go
+++ b/app/wasm_config.go
@@ -65,7 +65,7 @@ func NewDesmosCustomQueryPlugin(
 	profilesKeeper *profileskeeper.Keeper,
 	subspacesKeeper subspaceskeeper.Keeper,
 	relationshipsKeeper relationshipskeeper.Keeper,
-	postsKeeper postskeeper.Keeper,
+	postsKeeper *postskeeper.Keeper,
 	reportsKeeper reportskeeper.Keeper,
 	reactionsKeeper reactionskeeper.Keeper,
 ) wasmkeeper.QueryPlugins {

--- a/x/posts/abci.go
+++ b/x/posts/abci.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EndBlocker called every block, process ended polls
-func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) {
+func EndBlocker(ctx sdk.Context, keeper *keeper.Keeper) {
 	// Iterate over all the active polls that have been ended by the current block time
 	keeper.IterateActivePollsQueue(ctx, ctx.BlockTime(), func(poll types.Attachment) (stop bool) {
 		keeper.EndPoll(ctx, poll)

--- a/x/posts/keeper/common_test.go
+++ b/x/posts/keeper/common_test.go
@@ -31,7 +31,7 @@ type KeeperTestSuite struct {
 	ctx            sdk.Context
 
 	storeKey storetypes.StoreKey
-	k        keeper.Keeper
+	k        *keeper.Keeper
 
 	ak *testutil.MockProfilesKeeper
 	sk *testutil.MockSubspacesKeeper

--- a/x/posts/keeper/invariants.go
+++ b/x/posts/keeper/invariants.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RegisterInvariants registers all posts invariants
-func RegisterInvariants(ir sdk.InvariantRegistry, keeper Keeper) {
+func RegisterInvariants(ir sdk.InvariantRegistry, keeper *Keeper) {
 	ir.RegisterRoute(types.ModuleName, "valid-subspaces",
 		ValidSubspacesInvariant(keeper))
 	ir.RegisterRoute(types.ModuleName, "valid-posts",
@@ -29,7 +29,7 @@ func RegisterInvariants(ir sdk.InvariantRegistry, keeper Keeper) {
 // --------------------------------------------------------------------------------------------------------------------
 
 // ValidSubspacesInvariant checks that all the subspaces have a valid post id to them
-func ValidSubspacesInvariant(k Keeper) sdk.Invariant {
+func ValidSubspacesInvariant(k *Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (message string, broken bool) {
 		var invalidSubspaces []subspacestypes.Subspace
 		k.sk.IterateSubspaces(ctx, func(subspace subspacestypes.Subspace) (stop bool) {
@@ -59,7 +59,7 @@ func formatOutputSubspaces(subspaces []subspacestypes.Subspace) (output string) 
 // --------------------------------------------------------------------------------------------------------------------
 
 // ValidPostsInvariant checks that all the posts are valid
-func ValidPostsInvariant(k Keeper) sdk.Invariant {
+func ValidPostsInvariant(k *Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (message string, broken bool) {
 		var invalidPosts []types.Post
 		k.IteratePosts(ctx, func(post types.Post) (stop bool) {
@@ -122,7 +122,7 @@ func formatOutputPosts(posts []types.Post) (output string) {
 // --------------------------------------------------------------------------------------------------------------------
 
 // ValidAttachmentsInvariant checks that all the attachments are valid
-func ValidAttachmentsInvariant(k Keeper) sdk.Invariant {
+func ValidAttachmentsInvariant(k *Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (message string, broken bool) {
 		var invalidAttachments []types.Attachment
 		k.IterateAttachments(ctx, func(attachment types.Attachment) (stop bool) {
@@ -179,7 +179,7 @@ func formatOutputAttachments(attachments []types.Attachment) (output string) {
 // --------------------------------------------------------------------------------------------------------------------
 
 // ValidUserAnswersInvariant checks that all the user answers are valid
-func ValidUserAnswersInvariant(k Keeper) sdk.Invariant {
+func ValidUserAnswersInvariant(k *Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (message string, broken bool) {
 		var invalidUserAnswers []types.UserAnswer
 		k.IterateUserAnswers(ctx, func(answer types.UserAnswer) (stop bool) {
@@ -231,7 +231,7 @@ func formatOutputUserAnswers(answers []types.UserAnswer) (output string) {
 // --------------------------------------------------------------------------------------------------------------------
 
 // ValidActivePollsInvariant checks that all the active polls are valid
-func ValidActivePollsInvariant(k Keeper) sdk.Invariant {
+func ValidActivePollsInvariant(k *Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (message string, broken bool) {
 		var invalidActivePolls []types.Attachment
 		k.IterateActivePolls(ctx, func(attachment types.Attachment) (stop bool) {
@@ -262,7 +262,7 @@ func formatOutputActivePolls(polls []types.Attachment) (output string) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-func ValidPostOwnerTransferRequestsInvariant(k Keeper) sdk.Invariant {
+func ValidPostOwnerTransferRequestsInvariant(k *Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (message string, broken bool) {
 		var invalidPostOwnerTransferRequests []types.PostOwnerTransferRequest
 		k.IteratePostOwnerTransferRequests(ctx, func(request types.PostOwnerTransferRequest) (stop bool) {

--- a/x/posts/keeper/keeper.go
+++ b/x/posts/keeper/keeper.go
@@ -28,8 +28,8 @@ type Keeper struct {
 func NewKeeper(
 	cdc codec.BinaryCodec, storeKey storetypes.StoreKey,
 	ak types.ProfilesKeeper, sk types.SubspacesKeeper, rk types.RelationshipsKeeper, authority string,
-) Keeper {
-	return Keeper{
+) *Keeper {
+	return &Keeper{
 		storeKey: storeKey,
 		cdc:      cdc,
 

--- a/x/posts/keeper/migrations.go
+++ b/x/posts/keeper/migrations.go
@@ -16,14 +16,14 @@ import (
 
 // Migrator is a struct for handling in-place store migrations.
 type Migrator struct {
-	k  Keeper
+	k  *Keeper
 	sk types.SubspacesKeeper
 
 	legacySubspace types.ParamsSubspace
 }
 
 // NewMigrator returns a new Migrator
-func NewMigrator(keeper Keeper, sk types.SubspacesKeeper, legacySubspace types.ParamsSubspace) Migrator {
+func NewMigrator(keeper *Keeper, sk types.SubspacesKeeper, legacySubspace types.ParamsSubspace) Migrator {
 	return Migrator{
 		k:              keeper,
 		sk:             sk,

--- a/x/posts/keeper/msg_server.go
+++ b/x/posts/keeper/msg_server.go
@@ -16,12 +16,12 @@ import (
 )
 
 type msgServer struct {
-	Keeper
+	*Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the stored MsgServer interface
 // for the provided k
-func NewMsgServerImpl(keeper Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 

--- a/x/posts/module.go
+++ b/x/posts/module.go
@@ -125,10 +125,10 @@ type AppModule struct {
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(*am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
-	m := keeper.NewMigrator(*am.keeper, am.sk, am.legacySubspace)
+	m := keeper.NewMigrator(am.keeper, am.sk, am.legacySubspace)
 	err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
 	if err != nil {
 		panic(err)
@@ -177,7 +177,7 @@ func (AppModule) Name() string {
 
 // RegisterInvariants registers the module invariants
 func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
-	keeper.RegisterInvariants(ir, *am.keeper)
+	keeper.RegisterInvariants(ir, am.keeper)
 }
 
 // QuerierRoute returns the posts module's querier route name.
@@ -212,7 +212,7 @@ func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 // EndBlock returns the end blocker for the posts module. It returns no validator
 // updates.
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	EndBlocker(ctx, *am.keeper)
+	EndBlocker(ctx, am.keeper)
 	return []abci.ValidatorUpdate{}
 }
 
@@ -238,7 +238,7 @@ func (am AppModule) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {
 
 // WeightedOperations returns the all the posts module operations with their respective weights.
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
-	return simulation.WeightedOperations(simState.AppParams, simState.Cdc, *am.keeper, am.sk, am.ak, am.bk)
+	return simulation.WeightedOperations(simState.AppParams, simState.Cdc, am.keeper, am.sk, am.ak, am.bk)
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -309,7 +309,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 
 	m := NewAppModule(
 		in.Cdc,
-		&k,
+		k,
 		in.SubspacesKeeper,
 		in.AccountKeeper,
 		in.BankKeeper,
@@ -317,7 +317,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 	)
 
 	return ModuleOutputs{
-		PostsKeeper:    &k,
+		PostsKeeper:    k,
 		Module:         m,
 		SubspacesHooks: subspacestypes.SubspacesHooksWrapper{Hooks: k.Hooks()},
 	}

--- a/x/posts/simulation/operations.go
+++ b/x/posts/simulation/operations.go
@@ -50,7 +50,7 @@ const (
 // WeightedOperations returns all the operations from the module with their respective weights
 func WeightedOperations(
 	appParams simtypes.AppParams, cdc codec.JSONCodec,
-	k keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) sim.WeightedOperations {
 	var weightMsgCreatePost int
 	appParams.GetOrGenerate(cdc, OpWeightMsgCreatePost, &weightMsgCreatePost, nil,

--- a/x/posts/simulation/operations_attachments.go
+++ b/x/posts/simulation/operations_attachments.go
@@ -23,7 +23,7 @@ import (
 
 // SimulateMsgAddPostAttachment tests and runs a single msg add post attachment
 func SimulateMsgAddPostAttachment(
-	k keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -42,7 +42,7 @@ func SimulateMsgAddPostAttachment(
 
 // randomAddPostAttachmentFields returns the data needed to add an attachment to an existing post
 func randomAddPostAttachmentFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper,
 ) (subspaceID uint64, postID uint64, content types.AttachmentContent, editor simtypes.Account, skip bool) {
 	if len(accs) == 0 {
 		// Skip because there are no accounts
@@ -86,7 +86,7 @@ func randomAddPostAttachmentFields(
 
 // SimulateMsgRemovePostAttachment tests and runs a single msg remove post attachment
 func SimulateMsgRemovePostAttachment(
-	k keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -106,7 +106,7 @@ func SimulateMsgRemovePostAttachment(
 
 // randomRemovePostAttachmentFields returns the data needed to remove an attachment from an existing post
 func randomRemovePostAttachmentFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper, sk types.SubspacesKeeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper, sk types.SubspacesKeeper,
 ) (subspaceID uint64, postID uint64, attachmentID uint32, editor simtypes.Account, skip bool) {
 	if len(accs) == 0 {
 		// Skip because there are no accounts

--- a/x/posts/simulation/operations_polls.go
+++ b/x/posts/simulation/operations_polls.go
@@ -23,7 +23,7 @@ import (
 
 // SimulateMsgAnswerPoll tests and runs a single msg answer poll post
 func SimulateMsgAnswerPoll(
-	k keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -43,7 +43,7 @@ func SimulateMsgAnswerPoll(
 
 // randomAnswerPollFields returns the data needed to answer a user poll
 func randomAnswerPollFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper, sk types.SubspacesKeeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper, sk types.SubspacesKeeper,
 ) (answer types.UserAnswer, user simtypes.Account, skip bool) {
 	if len(accs) == 0 {
 		// Skip because there are no accounts

--- a/x/posts/simulation/operations_post_owner_transfer.go
+++ b/x/posts/simulation/operations_post_owner_transfer.go
@@ -19,7 +19,7 @@ import (
 
 // SimulateMsgRequestPostOwnerTransfer tests and runs a single msg request post owner transfer request
 func SimulateMsgRequestPostOwnerTransfer(
-	k keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -42,7 +42,7 @@ func SimulateMsgRequestPostOwnerTransfer(
 
 // randomRequestPostOwnerTransferFields returns the data needed to request a post owner transfer request
 func randomRequestPostOwnerTransferFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper,
 ) (request types.PostOwnerTransferRequest, signer simtypes.Account, skip bool) {
 
 	// Get a random post
@@ -102,7 +102,7 @@ func randomRequestPostOwnerTransferFields(
 
 // SimulateMsgCancelPostOwnerTransferRequest tests and runs a single msg cancel post owner transfer request
 func SimulateMsgCancelPostOwnerTransferRequest(
-	k keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -124,7 +124,7 @@ func SimulateMsgCancelPostOwnerTransferRequest(
 
 // randomCancelPostOwnerTransferFields returns the data needed to cancel a post owner transfer request
 func randomCancelPostOwnerTransferFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper,
 ) (request types.PostOwnerTransferRequest, signer simtypes.Account, skip bool) {
 
 	// Get a random post owner transfer request
@@ -152,7 +152,7 @@ func randomCancelPostOwnerTransferFields(
 
 // SimulateMsgAcceptPostOwnerTransferRequest tests and runs a single msg accept post owner transfer request
 func SimulateMsgAcceptPostOwnerTransferRequest(
-	k keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -174,7 +174,7 @@ func SimulateMsgAcceptPostOwnerTransferRequest(
 
 // randomAcceptPostOwnerTransferFields returns the data needed to accept a post owner transfer request
 func randomAcceptPostOwnerTransferFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper,
 ) (request types.PostOwnerTransferRequest, signer simtypes.Account, skip bool) {
 
 	// Get a random post owner transfer request
@@ -207,7 +207,7 @@ func randomAcceptPostOwnerTransferFields(
 
 // SimulateMsgRefusePostOwnerTransferRequest tests and runs a single msg refuse post owner transfer request
 func SimulateMsgRefusePostOwnerTransferRequest(
-	k keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -229,7 +229,7 @@ func SimulateMsgRefusePostOwnerTransferRequest(
 
 // randomRefusePostOwnerTransferFields returns the data needed to refuse a post owner transfer request
 func randomRefusePostOwnerTransferFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper,
 ) (request types.PostOwnerTransferRequest, signer simtypes.Account, skip bool) {
 
 	// Get a random post owner transfer request

--- a/x/posts/simulation/operations_posts.go
+++ b/x/posts/simulation/operations_posts.go
@@ -23,7 +23,7 @@ import (
 
 // SimulateMsgCreatePost tests and runs a single msg create post
 func SimulateMsgCreatePost(
-	k keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -54,7 +54,7 @@ func SimulateMsgCreatePost(
 
 // randomPostCreateFields returns the data needed to create a post
 func randomPostCreateFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper, sk types.SubspacesKeeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper, sk types.SubspacesKeeper,
 ) (post types.Post, author simtypes.Account, skip bool) {
 	if len(accs) == 0 {
 		// Skip because there are no accounts
@@ -107,7 +107,7 @@ func randomPostCreateFields(
 
 // SimulateMsgEditPost tests and runs a single msg edit post
 func SimulateMsgEditPost(
-	k keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -126,7 +126,7 @@ func SimulateMsgEditPost(
 
 // randomPostEditFields returns the data needed to edit a post
 func randomPostEditFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper, sk types.SubspacesKeeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper, sk types.SubspacesKeeper,
 ) (subspaceID uint64, postID uint64, update types.PostUpdate, editor simtypes.Account, skip bool) {
 	if len(accs) == 0 {
 		// Skip because there are no accounts
@@ -176,7 +176,7 @@ func randomPostEditFields(
 
 // SimulateMsgDeletePost tests and runs a single msg delete post
 func SimulateMsgDeletePost(
-	k keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -195,7 +195,7 @@ func SimulateMsgDeletePost(
 
 // randomPostEditFields returns the data needed to delete a post
 func randomPostDeleteFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper, sk types.SubspacesKeeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper, sk types.SubspacesKeeper,
 ) (subspaceID uint64, postID uint64, user simtypes.Account, skip bool) {
 	if len(accs) == 0 {
 		// Skip because there are no accounts
@@ -242,7 +242,7 @@ func randomPostDeleteFields(
 
 // SimulateMsgMovePost tests and runs a single msg move post
 func SimulateMsgMovePost(
-	k keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
+	k *keeper.Keeper, sk types.SubspacesKeeper, ak authkeeper.AccountKeeper, bk bankkeeper.Keeper,
 ) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
@@ -261,7 +261,7 @@ func SimulateMsgMovePost(
 
 // randomPostMoveFields returns the data needed to move a post
 func randomPostMoveFields(
-	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k keeper.Keeper, sk types.SubspacesKeeper,
+	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, k *keeper.Keeper, sk types.SubspacesKeeper,
 ) (subspaceID uint64, postID uint64, targetSubspaceID uint64, sectionID uint32, user simtypes.Account, skip bool) {
 	if len(accs) == 0 {
 		// Skip because there are no accounts

--- a/x/posts/wasm/common_test.go
+++ b/x/posts/wasm/common_test.go
@@ -96,7 +96,7 @@ type TestSuite struct {
 	ctx            sdk.Context
 
 	storeKey storetypes.StoreKey
-	k        keeper.Keeper
+	k        *keeper.Keeper
 }
 
 func TestTestSuite(t *testing.T) {

--- a/x/posts/wasm/querier.go
+++ b/x/posts/wasm/querier.go
@@ -18,11 +18,11 @@ import (
 var _ cosmwasm.Querier = PostsWasmQuerier{}
 
 type PostsWasmQuerier struct {
-	postsKeeper postskeeper.Keeper
+	postsKeeper *postskeeper.Keeper
 	cdc         codec.Codec
 }
 
-func NewPostsWasmQuerier(postsKeeper postskeeper.Keeper, cdc codec.Codec) PostsWasmQuerier {
+func NewPostsWasmQuerier(postsKeeper *postskeeper.Keeper, cdc codec.Codec) PostsWasmQuerier {
 	return PostsWasmQuerier{postsKeeper: postsKeeper, cdc: cdc}
 }
 


### PR DESCRIPTION
## Description

This PR improves posts keeper input and output consistency.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)