### PR TITLE
fix: disable buggy wasm metrics

### DIFF
--- a/app/app_config.go
+++ b/app/app_config.go
@@ -122,9 +122,9 @@ func GetWasmOpts(
 	reactionsKeeper reactionskeeper.Keeper,
 ) []wasmkeeper.Option {
 	var wasmOpts []wasmkeeper.Option
-	// FIXME (wasmd-1575): This is commented out temporarily because it causes panics in telemetry server due to buggy
-	// Bug has been fixed here: https://github.com/CosmWasm/wasmd/pull/1575
-	// and will be released in v0.42
+	// FIXME (wasmd-1575): This is commented out temporarily because it causes panics in telemetry server
+	// due to the bug fixed here: https://github.com/CosmWasm/wasmd/pull/1575.
+	// This will be released with CosmWasm v0.42, so we will un-comment this once we upgrade to that version.
 	// if cast.ToBool(appOpts.Get("telemetry.enabled")) {
 	// wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
 	// }

--- a/app/app_config.go
+++ b/app/app_config.go
@@ -18,10 +18,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/consensus"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	"github.com/spf13/cast"
 
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 
@@ -125,9 +122,12 @@ func GetWasmOpts(
 	reactionsKeeper reactionskeeper.Keeper,
 ) []wasmkeeper.Option {
 	var wasmOpts []wasmkeeper.Option
-	if cast.ToBool(appOpts.Get("telemetry.enabled")) {
-		wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
-	}
+	// FIXME (wasmd-1575): This is commented out temporarily because it causes panics in telemetry server due to buggy
+	// Bug has been fixed here: https://github.com/CosmWasm/wasmd/pull/1575
+	// and will be released in v0.42
+	// if cast.ToBool(appOpts.Get("telemetry.enabled")) {
+	// wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
+	// }
 
 	customQueryPlugin := NewDesmosCustomQueryPlugin(
 		cdc,


### PR DESCRIPTION
## Description

This PR disables the buggy wasm metrics in order to avoid node running failure.

Relates to https://github.com/CosmWasm/wasmd/issues/1574


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)