### PR TITLE
docs: update contracts bindings docs

### DIFF
--- a/docs/docs/02-developers/03-tools-to-build.md
+++ b/docs/docs/02-developers/03-tools-to-build.md
@@ -191,25 +191,26 @@ assertIsDeliverTxSuccess(result);
 
 ## Desmos Bindings
 The [Desmos Bindings](https://github.com/desmos-labs/desmos-bindings) are a set of packages that make possible to interact with the Desmos chain directly from smart contracts. With them, you can build your own dApp smart contracts taking full advantage of the Desmos chain modules to create even more personalisation to your app.   
-You can find the bindings generated documentation here: [Desmos Bindings docs](https://docs.rs/desmos-bindings/1.0.0/desmos_bindings/index.html). 
+You can find the bindings generated documentation here: [Desmos Bindings docs](https://docs.rs/desmos-bindings/latest/desmos_bindings/index.html). 
 
 ### Example 1: Post from a contract
 The below example shows you how to send a [`MsgCreatePost`](02-modules/posts/04-messages.md#msgcreatepost) from
 inside a smart contract.
 ```rust
-pub fn post_example_from_contract(deps: DepsMut, env: Env, info: MessageInfo, message: String) -> Result<Response<DesmosMsg>, ContractError> {
-    let post_msg = PostsMsg::CreatePost {
-        subspace_id: Uint64::new(1),
-        section_id: 1,
-        external_id: None,
-        text: Some(message),
-        entities: None,
-        attachments: None,
-        author: env.contract.address,
-        conversation_id: None,
-        reply_settings: ReplySetting::Unspecified,
+pub fn post_example_from_contract(deps: DepsMut, env: Env, info: MessageInfo, message: String) -> Result<Response<Empty>, ContractError> {
+    let post_msg = PostsMsg::create_post(
+        1,
+        1,
+        None,
+        "message",
+        None,
+        vec![],
+        vec![],
+        env.contract.address,
+        None,
+        ReplySetting::Unspecified,
         referenced_posts: vec![]
-    };
+    );
 
     let response = Response::new()
         .add_attribute("action", "post")
@@ -223,12 +224,9 @@ pub fn post_example_from_contract(deps: DepsMut, env: Env, info: MessageInfo, me
 ### Example 2: Query from a contract the Desmos chain state you need
 The below example shows you how to query a Subspace's posts from inside a smart contract.
 ```rust
-fn query_posts_from_contract(deps: Deps<DesmosQuery>, subspace_id: Uint64, pagination: Option<PageRequest>) -> StdResult<Binary> {
-    let request = DesmosQuery::Posts(PostsQuery::SubspacePosts {
-        subspace_id,
-        pagination,
-    });
-    let response: StdResult<QuerySubspacePostsResponse> = deps.querier.query(&request.into());
+fn query_posts_from_contract(deps: Deps, subspace_id: Uint64, pagination: Option<PageRequest>) -> StdResult<Binary> {
+    let querier = PostQuerier::new(&deps.querier);
+    let response: StdResult<QuerySubspacePostsResponse> = querier.query_subspace_posts(subspace_id, pagination);
 }
 ```
 


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR updates the docs of desmos-bindings part of `tools-to-build`, the current one is for v1.0.0 which is outdated.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)