### PR TITLE
fix: register missing interfaces to x/profiles module codec

### DIFF
--- a/x/profiles/ibc_module.go
+++ b/x/profiles/ibc_module.go
@@ -216,7 +216,7 @@ func handleLinkChainAccountPacketData(
 	am IBCModule, ctx sdk.Context, packet channeltypes.Packet,
 ) (handled bool, ack channeltypes.Acknowledgement, err error) {
 	var packetData types.LinkChainAccountPacketData
-	if err := types.ModuleCdc.UnmarshalJSON(packet.GetData(), &packetData); err != nil {
+	if err := types.ModuleCdc().UnmarshalJSON(packet.GetData(), &packetData); err != nil {
 		return false, channeltypes.Acknowledgement{}, nil
 	}
 
@@ -259,7 +259,7 @@ func handleOracleRequestPacketData(
 	am IBCModule, ctx sdk.Context, packet channeltypes.Packet,
 ) (handled bool, ack channeltypes.Acknowledgement, err error) {
 	var data oracletypes.OracleResponsePacketData
-	if err := types.ModuleCdc.UnmarshalJSON(packet.GetData(), &data); err != nil {
+	if err := types.ModuleCdc().UnmarshalJSON(packet.GetData(), &data); err != nil {
 		return false, channeltypes.Acknowledgement{}, nil
 	}
 
@@ -295,14 +295,14 @@ func (am IBCModule) OnAcknowledgementPacket(
 	relayer sdk.AccAddress,
 ) error {
 	var ack channeltypes.Acknowledgement
-	err := types.ModuleCdc.UnmarshalJSON(acknowledgement, &ack)
+	err := types.ModuleCdc().UnmarshalJSON(acknowledgement, &ack)
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrUnknownRequest,
 			"cannot unmarshal oracle packet acknowledgement: %v", err)
 	}
 
 	var data oracletypes.OracleRequestPacketData
-	err = types.ModuleCdc.UnmarshalJSON(packet.GetData(), &data)
+	err = types.ModuleCdc().UnmarshalJSON(packet.GetData(), &data)
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrUnknownRequest,
 			"cannot unmarshal oracle request packet data: %s", err)
@@ -351,7 +351,7 @@ func (am IBCModule) OnTimeoutPacket(
 	relayer sdk.AccAddress,
 ) error {
 	var data oracletypes.OracleRequestPacketData
-	err := types.ModuleCdc.UnmarshalJSON(packet.GetData(), &data)
+	err := types.ModuleCdc().UnmarshalJSON(packet.GetData(), &data)
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrUnknownRequest,
 			"cannot unmarshal oracle request packet data: %s", err)

--- a/x/profiles/keeper/relay_app_links.go
+++ b/x/profiles/keeper/relay_app_links.go
@@ -232,7 +232,7 @@ func (k Keeper) OnOracleRequestAcknowledgementPacket(
 		link.State = types.AppLinkStateVerificationStarted
 
 		var packetAck oracletypes.OracleRequestPacketAcknowledgement
-		err = types.ModuleCdc.UnmarshalJSON(res.Result, &packetAck)
+		err = types.ModuleCdc().UnmarshalJSON(res.Result, &packetAck)
 		if err != nil {
 			return fmt.Errorf("cannot unmarshal oracle request packet acknowledgment: %s", err)
 		}

--- a/x/profiles/keeper/relay_app_links_test.go
+++ b/x/profiles/keeper/relay_app_links_test.go
@@ -746,7 +746,7 @@ func (suite *KeeperTestSuite) TestKeeper_OnOracleRequestAcknowledgementPacket() 
 				suite.Require().NoError(err)
 			},
 			data:      createRequestPacketData("client_id"),
-			ack:       channeltypes.NewResultAcknowledgement(types.ModuleCdc.MustMarshalJSON(&result)),
+			ack:       channeltypes.NewResultAcknowledgement(types.ModuleCdc().MustMarshalJSON(&result)),
 			shouldErr: false,
 			expLink: types.NewApplicationLink(
 				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",

--- a/x/profiles/types/codec.go
+++ b/x/profiles/types/codec.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -64,6 +65,10 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 		&SingleSignature{},
 		&CosmosMultiSignature{},
 	)
+	registry.RegisterImplementations(
+		(*cryptotypes.PubKey)(nil),
+		&ethsecp256k1.PubKey{},
+	)
 
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgSaveProfile{},
@@ -83,18 +88,30 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
+// ModuleCdc references the global x/profiles protobuf codec. Note, the codec should
+// ONLY be used in certain instances of tests and for JSON encoding.
+//
+// The actual codec used for serialization should be provided to x/profiles and
+// defined at the application level.
+func ModuleCdc() *codec.ProtoCodec {
+	// Register required interfaces to registry
+	registry := types.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry)
+	RegisterInterfaces(registry)
+
+	return codec.NewProtoCodec(registry)
+}
+
 var (
 	amino = codec.NewLegacyAmino()
 
-	// AminoCdc references the global x/relationships module codec. Note, the codec should
+	// AminoCdc references the global x/profiles module codec. Note, the codec should
 	// ONLY be used in certain instances of tests and for JSON encoding as Amino is
 	// still used for that purpose.
 	//
-	// The actual codec used for serialization should be provided to x/relationships and
+	// The actual codec used for serialization should be provided to x/profiles and
 	// defined at the application level.
 	AminoCdc = codec.NewAminoCodec(amino)
-
-	ModuleCdc = codec.NewProtoCodec(types.NewInterfaceRegistry())
 )
 
 func init() {

--- a/x/profiles/types/models_packets.go
+++ b/x/profiles/types/models_packets.go
@@ -62,6 +62,5 @@ func (p LinkChainAccountPacketData) Validate() error {
 
 // GetBytes is a helper for serialising
 func (p LinkChainAccountPacketData) GetBytes() ([]byte, error) {
-	var modulePacket LinkChainAccountPacketData
-	return sdk.SortJSON(ModuleCdc.MustMarshalJSON(&modulePacket))
+	return sdk.SortJSON(ModuleCdc().MustMarshalJSON(&p))
 }

--- a/x/profiles/types/models_packets_test.go
+++ b/x/profiles/types/models_packets_test.go
@@ -138,13 +138,15 @@ func TestLinkChainAccountPacketData_Validate(t *testing.T) {
 }
 
 func TestLinkChainAccountPacketData_GetBytes(t *testing.T) {
+	pubKey := profilestesting.PubKeyFromBech32("cosmospub1addwnpepqvryxhhqhw52c4ny5twtfzf3fsrjqhx0x5cuya0fylw0wu0eqptykeqhr4d")
 	packetData := types.NewLinkChainAccountPacketData(
 		types.NewBech32Address("cosmos1yt7rqhj0hjw92ed0948r2pqwtp9smukurqcs70", "cosmos"),
-		types.NewProof(secp256k1.GenPrivKey().PubKey(), profilestesting.SingleSignatureFromHex("032086ede8d4bce29fe364a94744ca71dbeaf370221ba20f9716a165c54b079561"), "plain_text"),
+		types.NewProof(pubKey, profilestesting.SingleSignatureFromHex("032086ede8d4bce29fe364a94744ca71dbeaf370221ba20f9716a165c54b079561"), "plain_text"),
 		types.NewChainConfig("cosmos"),
 		"cosmos1yt7rqhj0hjw92ed0948r2pqwtp9smukurqcs70",
-		types.NewProof(secp256k1.GenPrivKey().PubKey(), profilestesting.SingleSignatureFromHex("032086ede8d4bce29fe364a94744ca71dbeaf370221ba20f9716a165c54b079561"), "plain_text"),
+		types.NewProof(pubKey, profilestesting.SingleSignatureFromHex("032086ede8d4bce29fe364a94744ca71dbeaf370221ba20f9716a165c54b079561"), "plain_text"),
 	)
-	_, err := packetData.GetBytes()
+	bz, err := packetData.GetBytes()
 	require.NoError(t, err)
+	require.Equal(t, "{\"destination_address\":\"cosmos1yt7rqhj0hjw92ed0948r2pqwtp9smukurqcs70\",\"destination_proof\":{\"plain_text\":\"plain_text\",\"pub_key\":{\"@type\":\"/cosmos.crypto.secp256k1.PubKey\",\"key\":\"AwZDXuC7qKxWZKLctIkxTAcgXM81McJ16Sfc93H5AFZL\"},\"signature\":{\"@type\":\"/desmos.profiles.v3.SingleSignature\",\"signature\":\"AyCG7ejUvOKf42SpR0TKcdvq83AiG6IPlxahZcVLB5Vh\",\"value_type\":\"SIGNATURE_VALUE_TYPE_RAW\"}},\"source_address\":{\"@type\":\"/desmos.profiles.v3.Bech32Address\",\"prefix\":\"cosmos\",\"value\":\"cosmos1yt7rqhj0hjw92ed0948r2pqwtp9smukurqcs70\"},\"source_chain_config\":{\"name\":\"cosmos\"},\"source_proof\":{\"plain_text\":\"plain_text\",\"pub_key\":{\"@type\":\"/cosmos.crypto.secp256k1.PubKey\",\"key\":\"AwZDXuC7qKxWZKLctIkxTAcgXM81McJ16Sfc93H5AFZL\"},\"signature\":{\"@type\":\"/desmos.profiles.v3.SingleSignature\",\"signature\":\"AyCG7ejUvOKf42SpR0TKcdvq83AiG6IPlxahZcVLB5Vh\",\"value_type\":\"SIGNATURE_VALUE_TYPE_RAW\"}}}", string(bz))
 }


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
This PR fixes the registry with empty interfaces, it causes the `LinkChainAccountPacketData` can not be parsed properly with the error: 
```
unable to resolve type URL /cosmos.crypto.secp256k1.PubKey
unable to resolve type URL /desmos.profiles.v3.Bech32Address
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)