### PR TITLE
fix: remove duplicated message type events

### DIFF
--- a/.changeset/entries/d3f03fad99e3c68e9114b638351cde7983870148f84626f49c69e2b52dc5abed.yaml
+++ b/.changeset/entries/d3f03fad99e3c68e9114b638351cde7983870148f84626f49c69e2b52dc5abed.yaml
@@ -1,0 +1,6 @@
+type: fix
+module: none
+pull_request: 5299
+description: 'fix: remove duplicated message type events'
+backward_compatible: true
+date: 2023-12-28T10:10:27.551132142Z

--- a/x/posts/keeper/msg_server.go
+++ b/x/posts/keeper/msg_server.go
@@ -103,12 +103,6 @@ func (k msgServer) CreatePost(goCtx context.Context, msg *types.MsgCreatePost) (
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Author),
-		),
-		sdk.NewEvent(
 			types.EventTypeCreatePost,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeySectionID, fmt.Sprintf("%d", msg.SectionID)),
@@ -163,12 +157,6 @@ func (k msgServer) EditPost(goCtx context.Context, msg *types.MsgEditPost) (*typ
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Editor),
-		),
-		sdk.NewEvent(
 			types.EventTypeEditPost,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
@@ -207,12 +195,6 @@ func (k msgServer) DeletePost(goCtx context.Context, msg *types.MsgDeletePost) (
 	k.Keeper.DeletePost(ctx, msg.SubspaceID, msg.PostID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeDeletePost,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -314,12 +296,6 @@ func (k msgServer) AddPostAttachment(goCtx context.Context, msg *types.MsgAddPos
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Editor),
-		),
-		sdk.NewEvent(
 			types.EventTypeAddPostAttachment,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
@@ -376,12 +352,6 @@ func (k msgServer) RemovePostAttachment(goCtx context.Context, msg *types.MsgRem
 	k.SavePost(ctx, post)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Editor),
-		),
 		sdk.NewEvent(
 			types.EventTypeRemovePostAttachment,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -462,12 +432,6 @@ func (k msgServer) AnswerPoll(goCtx context.Context, msg *types.MsgAnswerPoll) (
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeAnswerPoll,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
@@ -487,15 +451,6 @@ func (m msgServer) UpdateParams(goCtx context.Context, msg *types.MsgUpdateParam
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	m.SetParams(ctx, msg.Params)
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Authority),
-		),
-	})
 
 	return &types.MsgUpdateParamsResponse{}, nil
 }
@@ -575,12 +530,6 @@ func (k msgServer) MovePost(goCtx context.Context, msg *types.MsgMovePost) (*typ
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Owner),
-		),
-		sdk.NewEvent(
 			types.EventTypeMovePost,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
@@ -637,12 +586,6 @@ func (k msgServer) RequestPostOwnerTransfer(goCtx context.Context, msg *types.Ms
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-		sdk.NewEvent(
 			types.EventTypeRequestPostOwnerTransfer,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
@@ -673,12 +616,6 @@ func (k msgServer) CancelPostOwnerTransferRequest(goCtx context.Context, msg *ty
 	k.DeletePostOwnerTransferRequest(ctx, msg.SubspaceID, msg.PostID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
 		sdk.NewEvent(
 			types.EventTypeCancelPostOwnerTransfer,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -736,12 +673,6 @@ func (k msgServer) AcceptPostOwnerTransferRequest(goCtx context.Context, msg *ty
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Receiver),
-		),
-		sdk.NewEvent(
 			types.EventTypeAcceptPostOwnerTransfer,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
@@ -771,12 +702,6 @@ func (k msgServer) RefusePostOwnerTransferRequest(goCtx context.Context, msg *ty
 	k.DeletePostOwnerTransferRequest(ctx, msg.SubspaceID, msg.PostID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Receiver),
-		),
 		sdk.NewEvent(
 			types.EventTypeRefusePostOwnerTransfer,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),

--- a/x/posts/keeper/msg_server_test.go
+++ b/x/posts/keeper/msg_server_test.go
@@ -364,12 +364,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreatePost() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreatePost{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
-				sdk.NewEvent(
 					types.EventTypeCreatePost,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeySectionID, "0"),
@@ -485,12 +479,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreatePost() {
 				CreationDate: time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
 			},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreatePost{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
 				sdk.NewEvent(
 					types.EventTypeCreatePost,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -779,12 +767,6 @@ func (suite *KeeperTestSuite) TestMsgServer_EditPost() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgEditPost{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
-				sdk.NewEvent(
 					types.EventTypeEditPost,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -986,12 +968,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeletePost() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeletePost{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1r9jamre0x0qqy562rhhckt6sryztwhnvhafyz4"),
-				),
-				sdk.NewEvent(
 					types.EventTypeDeletePost,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -1042,12 +1018,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeletePost() {
 			},
 			msg: types.NewMsgDeletePost(1, 1, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeletePost{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDeletePost,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -1289,12 +1259,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AddPostAttachment() {
 				EditDate:     time.Date(2021, 1, 1, 12, 00, 00, 000, time.UTC),
 			},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAddPostAttachment{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
 				sdk.NewEvent(
 					types.EventTypeAddPostAttachment,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -1620,12 +1584,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RemovePostAttachment() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRemovePostAttachment{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1r9jamre0x0qqy562rhhckt6sryztwhnvhafyz4"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRemovePostAttachment,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -1707,12 +1665,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RemovePostAttachment() {
 				EditDate: time.Date(2021, 1, 1, 12, 00, 00, 000, time.UTC),
 			},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRemovePostAttachment{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
 				sdk.NewEvent(
 					types.EventTypeRemovePostAttachment,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -2236,12 +2188,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AnswerPoll() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAnswerPoll{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
-				sdk.NewEvent(
 					types.EventTypeAnswerPoll,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -2323,12 +2269,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AnswerPoll() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAnswerPoll{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
-				sdk.NewEvent(
 					types.EventTypeAnswerPoll,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -2403,14 +2343,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateParams() {
 				authtypes.NewModuleAddress("gov").String(),
 			),
 			shouldErr: false,
-			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUpdateParams{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn"),
-				),
-			},
+			expEvents: sdk.Events{},
 			check: func(ctx sdk.Context) {
 				params := suite.k.GetParams(ctx)
 				suite.Require().Equal(types.DefaultParams(), params)
@@ -2833,12 +2766,6 @@ func (suite *KeeperTestSuite) TestMsgServer_MovePost() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgMovePost{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
-				sdk.NewEvent(
 					types.EventTypeMovePost,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -3228,12 +3155,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RequestPostOwnerTransfer() {
 			expResponse: &types.MsgRequestPostOwnerTransferResponse{},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRequestPostOwnerTransfer{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRequestPostOwnerTransfer,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -3342,12 +3263,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CancelPostOwnerTransfer() {
 			),
 			expResponse: &types.MsgCancelPostOwnerTransferRequestResponse{},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCancelPostOwnerTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1eqpa6mv2jgevukaqtjmx5535vhc3mm3cf458zg"),
-				),
 				sdk.NewEvent(
 					types.EventTypeCancelPostOwnerTransfer,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -3589,12 +3504,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AcceptPostOwnerTransfer() {
 			expResponse: &types.MsgAcceptPostOwnerTransferRequestResponse{},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAcceptPostOwnerTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
-				sdk.NewEvent(
 					types.EventTypeAcceptPostOwnerTransfer,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -3689,12 +3598,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RefusePostOwnerTransfer() {
 			),
 			expResponse: &types.MsgRefusePostOwnerTransferRequestResponse{},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRefusePostOwnerTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos13t6y2nnugtshwuy0zkrq287a95lyy8vzleaxmd"),
-				),
 				sdk.NewEvent(
 					types.EventTypeRefusePostOwnerTransfer,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),

--- a/x/posts/types/events.go
+++ b/x/posts/types/events.go
@@ -14,8 +14,8 @@ const (
 	EventTypeCancelPostOwnerTransfer  = "cancel_post_owner_transfer"
 	EventTypeAcceptPostOwnerTransfer  = "accept_post_owner_transfer"
 	EventTypeRefusePostOwnerTransfer  = "refuse_post_owner_transfer"
+	EventTypeUpdateParams             = "update_params"
 
-	AttributeValueCategory    = ModuleName
 	AttributeKeySubspaceID    = "subspace_id"
 	AttributeKeySectionID     = "section_id"
 	AttributeKeyPostID        = "post_id"

--- a/x/posts/types/events.go
+++ b/x/posts/types/events.go
@@ -14,7 +14,6 @@ const (
 	EventTypeCancelPostOwnerTransfer  = "cancel_post_owner_transfer"
 	EventTypeAcceptPostOwnerTransfer  = "accept_post_owner_transfer"
 	EventTypeRefusePostOwnerTransfer  = "refuse_post_owner_transfer"
-	EventTypeUpdateParams             = "update_params"
 
 	AttributeKeySubspaceID    = "subspace_id"
 	AttributeKeySectionID     = "section_id"

--- a/x/profiles/keeper/msg_server_app_link.go
+++ b/x/profiles/keeper/msg_server_app_link.go
@@ -49,12 +49,6 @@ func (k Keeper) LinkApplication(
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-		sdk.NewEvent(
 			types.EventTypesApplicationLinkCreated,
 			sdk.NewAttribute(types.AttributeKeyUser, msg.Sender),
 			sdk.NewAttribute(types.AttributeKeyApplicationName, msg.LinkData.Application),
@@ -89,15 +83,6 @@ func (k MsgServer) UnlinkApplication(
 		"application", msg.Application,
 		"username", msg.Username,
 		"account", msg.Signer)
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-	})
 
 	return &types.MsgUnlinkApplicationResponse{}, nil
 }

--- a/x/profiles/keeper/msg_server_app_link_test.go
+++ b/x/profiles/keeper/msg_server_app_link_test.go
@@ -237,12 +237,6 @@ func (suite *KeeperTestSuite) TestMsgServer_LinkApplication() {
 					sdk.NewAttribute(types.AttributeKeyApplicationUsername, "twitteruser"),
 				),
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgLinkApplication{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
-				),
-				sdk.NewEvent(
 					types.EventTypesApplicationLinkCreated,
 					sdk.NewAttribute(types.AttributeKeyUser, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
 					sdk.NewAttribute(types.AttributeKeyApplicationName, "twitter"),
@@ -347,12 +341,6 @@ func (suite *KeeperTestSuite) TestMsgServer_LinkApplication() {
 					sdk.NewAttribute(types.AttributeKeyUser, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
 					sdk.NewAttribute(types.AttributeKeyApplicationName, "twitter"),
 					sdk.NewAttribute(types.AttributeKeyApplicationUsername, "twitteruser"),
-				),
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgLinkApplication{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
 				),
 				sdk.NewEvent(
 					types.EventTypesApplicationLinkCreated,
@@ -527,12 +515,6 @@ func (suite *KeeperTestSuite) TestMsgServer_UnlinkApplication() {
 					sdk.NewAttribute(types.AttributeKeyApplicationName, "twitter"),
 					sdk.NewAttribute(types.AttributeKeyApplicationUsername, "twitteruser"),
 					sdk.NewAttribute(types.AttributeKeyApplicationLinkExpirationTime, time.Date(2020, 3, 1, 00, 00, 00, 000, time.UTC).Format(time.RFC3339)),
-				),
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUnlinkApplication{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
 				),
 			},
 			check: func(ctx sdk.Context) {

--- a/x/profiles/keeper/msg_server_chain_link.go
+++ b/x/profiles/keeper/msg_server_chain_link.go
@@ -29,12 +29,6 @@ func (k MsgServer) LinkChainAccount(goCtx context.Context, msg *types.MsgLinkCha
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeLinkChainAccount,
 			sdk.NewAttribute(types.AttributeKeyChainLinkExternalAddress, srcAddrData.GetValue()),
 			sdk.NewAttribute(types.AttributeKeyChainLinkChainName, msg.ChainConfig.Name),
@@ -61,12 +55,6 @@ func (k MsgServer) UnlinkChainAccount(goCtx context.Context, msg *types.MsgUnlin
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Owner),
-		),
-		sdk.NewEvent(
 			types.EventTypeUnlinkChainAccount,
 			sdk.NewAttribute(types.AttributeKeyChainLinkExternalAddress, msg.Target),
 			sdk.NewAttribute(types.AttributeKeyChainLinkChainName, msg.ChainName),
@@ -90,12 +78,6 @@ func (k MsgServer) SetDefaultExternalAddress(goCtx context.Context, msg *types.M
 	k.SaveDefaultExternalAddress(ctx, msg.Signer, msg.ChainName, msg.Target)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeSetDefaultExternalAddress,
 			sdk.NewAttribute(types.AttributeKeyChainLinkChainName, msg.ChainName),

--- a/x/profiles/keeper/msg_server_chain_link_test.go
+++ b/x/profiles/keeper/msg_server_chain_link_test.go
@@ -108,12 +108,6 @@ func (suite *KeeperTestSuite) TestMsgServer_LinkChainAccount() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgLinkChainAccount{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, destAddr),
-				),
-				sdk.NewEvent(
 					types.EventTypeLinkChainAccount,
 					sdk.NewAttribute(types.AttributeKeyChainLinkExternalAddress, srcAddr),
 					sdk.NewAttribute(types.AttributeKeyChainLinkChainName, "cosmos"),
@@ -204,12 +198,6 @@ func (suite *KeeperTestSuite) TestMsgServer_UnlinkChainAccount() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUnlinkChainAccount{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
 				sdk.NewEvent(
 					types.EventTypeUnlinkChainAccount,
 					sdk.NewAttribute(types.AttributeKeyChainLinkExternalAddress, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
@@ -306,12 +294,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SetDefaultExternalAddress() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSetDefaultExternalAddress{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
 				sdk.NewEvent(
 					types.EventTypeSetDefaultExternalAddress,
 					sdk.NewAttribute(types.AttributeKeyChainLinkChainName, "cosmos"),

--- a/x/profiles/keeper/msg_server_dtag_transfers.go
+++ b/x/profiles/keeper/msg_server_dtag_transfers.go
@@ -45,12 +45,6 @@ func (k MsgServer) RequestDTagTransfer(goCtx context.Context, msg *types.MsgRequ
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-		sdk.NewEvent(
 			types.EventTypeDTagTransferRequest,
 			sdk.NewAttribute(types.AttributeKeyDTagToTrade, dTagToTrade),
 			sdk.NewAttribute(types.AttributeKeyRequestSender, transferRequest.Sender),
@@ -74,12 +68,6 @@ func (k MsgServer) CancelDTagTransferRequest(goCtx context.Context, msg *types.M
 	k.DeleteDTagTransferRequest(ctx, msg.Sender, msg.Receiver)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
 		sdk.NewEvent(
 			types.EventTypeDTagTransferCancel,
 			sdk.NewAttribute(types.AttributeKeyRequestSender, msg.Sender),
@@ -178,12 +166,6 @@ func (k MsgServer) AcceptDTagTransferRequest(goCtx context.Context, msg *types.M
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Receiver),
-		),
-		sdk.NewEvent(
 			types.EventTypeDTagTransferAccept,
 			sdk.NewAttribute(types.AttributeKeyDTagToTrade, dTagToTrade),
 			sdk.NewAttribute(types.AttributeKeyNewDTag, msg.NewDTag),
@@ -208,12 +190,6 @@ func (k MsgServer) RefuseDTagTransferRequest(goCtx context.Context, msg *types.M
 	k.DeleteDTagTransferRequest(ctx, msg.Sender, msg.Receiver)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Receiver),
-		),
 		sdk.NewEvent(
 			types.EventTypeDTagTransferRefuse,
 			sdk.NewAttribute(types.AttributeKeyRequestSender, msg.Sender),

--- a/x/profiles/keeper/msg_server_dtag_transfers_test.go
+++ b/x/profiles/keeper/msg_server_dtag_transfers_test.go
@@ -83,12 +83,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RequestDTagTransfer() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRequestDTagTransfer{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
-				sdk.NewEvent(
 					types.EventTypeDTagTransferRequest,
 					sdk.NewAttribute(types.AttributeKeyDTagToTrade, fmt.Sprintf("%s-dtag", "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns")),
 					sdk.NewAttribute(types.AttributeKeyRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
@@ -155,12 +149,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CancelDTagTransfer() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCancelDTagTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDTagTransferCancel,
 					sdk.NewAttribute(types.AttributeKeyRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
@@ -379,12 +367,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AcceptDTagTransfer() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAcceptDTagTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
-				),
-				sdk.NewEvent(
 					types.EventTypeDTagTransferAccept,
 					sdk.NewAttribute(types.AttributeKeyDTagToTrade, "DTag"),
 					sdk.NewAttribute(types.AttributeKeyNewDTag, "NewDtag"),
@@ -413,12 +395,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AcceptDTagTransfer() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 			),
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAcceptDTagTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDTagTransferAccept,
 					sdk.NewAttribute(types.AttributeKeyDTagToTrade, "DTag"),
@@ -457,12 +433,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AcceptDTagTransfer() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 			),
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAcceptDTagTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDTagTransferAccept,
 					sdk.NewAttribute(types.AttributeKeyDTagToTrade, "receiverDTag"),
@@ -540,12 +510,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RefuseDTagTransfer() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRefuseDTagTransferRequest{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDTagTransferRefuse,
 					sdk.NewAttribute(types.AttributeKeyRequestSender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),

--- a/x/profiles/keeper/msg_server_params.go
+++ b/x/profiles/keeper/msg_server_params.go
@@ -20,14 +20,5 @@ func (m MsgServer) UpdateParams(goCtx context.Context, msg *types.MsgUpdateParam
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	m.SetParams(ctx, msg.Params)
 
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Authority),
-		),
-	})
-
 	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/profiles/keeper/msg_server_params_test.go
+++ b/x/profiles/keeper/msg_server_params_test.go
@@ -31,14 +31,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateParams() {
 				authtypes.NewModuleAddress("gov").String(),
 			),
 			shouldErr: false,
-			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUpdateParams{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn"),
-				),
-			},
+			expEvents: sdk.Events{},
 			check: func(ctx sdk.Context) {
 				params := suite.k.GetParams(ctx)
 				suite.Require().Equal(types.DefaultParams(), params)

--- a/x/profiles/keeper/msgs_server_profile.go
+++ b/x/profiles/keeper/msgs_server_profile.go
@@ -71,12 +71,6 @@ func (k MsgServer) SaveProfile(goCtx context.Context, msg *types.MsgSaveProfile)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Creator),
-		),
-		sdk.NewEvent(
 			types.EventTypeProfileSaved,
 			sdk.NewAttribute(types.AttributeKeyProfileDTag, updated.DTag),
 			sdk.NewAttribute(types.AttributeKeyProfileCreator, updated.GetAddress().String()),
@@ -97,12 +91,6 @@ func (k MsgServer) DeleteProfile(goCtx context.Context, msg *types.MsgDeleteProf
 	}
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Creator),
-		),
 		sdk.NewEvent(
 			types.EventTypeProfileDeleted,
 			sdk.NewAttribute(types.AttributeKeyProfileCreator, msg.Creator),

--- a/x/profiles/keeper/msgs_server_profile_test.go
+++ b/x/profiles/keeper/msgs_server_profile_test.go
@@ -51,12 +51,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SaveProfile() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSaveProfile{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
-				),
-				sdk.NewEvent(
 					types.EventTypeProfileSaved,
 					sdk.NewAttribute(types.AttributeKeyProfileDTag, "custom_dtag"),
 					sdk.NewAttribute(types.AttributeKeyProfileCreator, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
@@ -90,12 +84,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SaveProfile() {
 				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
 			),
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSaveProfile{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
-				),
 				sdk.NewEvent(
 					types.EventTypeProfileSaved,
 					sdk.NewAttribute(types.AttributeKeyProfileDTag, "other_dtag"),
@@ -136,12 +124,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SaveProfile() {
 				"cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773",
 			),
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSaveProfile{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
-				),
 				sdk.NewEvent(
 					types.EventTypeProfileSaved,
 					sdk.NewAttribute(types.AttributeKeyProfileDTag, "Test"),
@@ -220,12 +202,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SaveProfile() {
 				"cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns",
 			),
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSaveProfile{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
-				),
 				sdk.NewEvent(
 					types.EventTypeProfileSaved,
 					sdk.NewAttribute(types.AttributeKeyProfileDTag, "tomtom"),
@@ -317,12 +293,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteProfile() {
 			msg:       types.NewMsgDeleteProfile("cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeleteProfile{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),
-				),
 				sdk.NewEvent(
 					types.EventTypeProfileDeleted,
 					sdk.NewAttribute(types.AttributeKeyProfileCreator, "cosmos10nsdxxdvy9qka3zv0lzw8z9cnu6kanld8jh773"),

--- a/x/profiles/types/events.go
+++ b/x/profiles/types/events.go
@@ -42,6 +42,4 @@ const (
 	AttributeKeyResolveStatus                 = "resolve_status"
 	AttributeKeyAck                           = "acknowledgement"
 	AttributeKeyAckError                      = "error"
-
-	AttributeValueCategory = ModuleName
 )

--- a/x/reactions/keeper/msg_server.go
+++ b/x/reactions/keeper/msg_server.go
@@ -90,12 +90,6 @@ func (k msgServer) AddReaction(goCtx context.Context, msg *types.MsgAddReaction)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
-		),
-		sdk.NewEvent(
 			types.EventTypeAddReaction,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyPostID, fmt.Sprintf("%d", msg.PostID)),
@@ -144,12 +138,6 @@ func (k msgServer) RemoveReaction(goCtx context.Context, msg *types.MsgRemoveRea
 	k.DeleteReaction(ctx, msg.SubspaceID, msg.PostID, msg.ReactionID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
-		),
 		sdk.NewEvent(
 			types.EventTypeRemoveReaction,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -201,12 +189,6 @@ func (k msgServer) AddRegisteredReaction(goCtx context.Context, msg *types.MsgAd
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
-		),
-		sdk.NewEvent(
 			types.ActionAddRegisteredReaction,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyRegisteredReactionID, fmt.Sprintf("%d", reaction.ID)),
@@ -250,12 +232,6 @@ func (k msgServer) EditRegisteredReaction(goCtx context.Context, msg *types.MsgE
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
-		),
-		sdk.NewEvent(
 			types.ActionEditRegisteredReaction,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyRegisteredReactionID, fmt.Sprintf("%d", msg.RegisteredReactionID)),
@@ -288,12 +264,6 @@ func (k msgServer) RemoveRegisteredReaction(goCtx context.Context, msg *types.Ms
 	k.DeleteRegisteredReaction(ctx, msg.SubspaceID, msg.RegisteredReactionID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
-		),
 		sdk.NewEvent(
 			types.EventTypeRemoveRegisteredReaction,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -329,12 +299,6 @@ func (k msgServer) SetReactionsParams(goCtx context.Context, msg *types.MsgSetRe
 	k.SaveSubspaceReactionsParams(ctx, params)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.User),
-		),
 		sdk.NewEvent(
 			types.EventTypeSetReactionsParams,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),

--- a/x/reactions/keeper/msg_server_test.go
+++ b/x/reactions/keeper/msg_server_test.go
@@ -416,12 +416,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AddReaction() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAddReaction{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
-				),
-				sdk.NewEvent(
 					types.EventTypeAddReaction,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -507,12 +501,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AddReaction() {
 				ReactionID: 1,
 			},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAddReaction{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
-				),
 				sdk.NewEvent(
 					types.EventTypeAddReaction,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -792,12 +780,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RemoveReaction() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRemoveReaction{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRemoveReaction,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyPostID, "1"),
@@ -964,12 +946,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AddRegisteredReaction() {
 				RegisteredReactionID: 1,
 			},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAddRegisteredReaction{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
-				),
 				sdk.NewEvent(
 					types.EventTypeAddRegisteredReaction,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -1161,12 +1137,6 @@ func (suite *KeeperTestSuite) TestMsgServer_EditRegisteredReaction() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgEditRegisteredReaction{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
-				),
-				sdk.NewEvent(
 					types.ActionEditRegisteredReaction,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyRegisteredReactionID, "1"),
@@ -1311,12 +1281,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RemoveRegisteredReaction() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRemoveRegisteredReaction{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRemoveRegisteredReaction,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyRegisteredReactionID, "1"),
@@ -1449,12 +1413,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SetReactionsParams() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSetReactionsParams{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1efa8l9h4p6hmkps6vk8lu7nxydr46npr8qtg5f"),
-				),
 				sdk.NewEvent(
 					types.EventTypeSetReactionsParams,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),

--- a/x/reactions/types/events.go
+++ b/x/reactions/types/events.go
@@ -9,7 +9,6 @@ const (
 	EventTypeRemoveRegisteredReaction = "removed_registered_reaction"
 	EventTypeSetReactionsParams       = "set_reactions_params"
 
-	AttributeValueCategory           = ModuleName
 	AttributeKeySubspaceID           = "subspace_id"
 	AttributeKeyPostID               = "post_id"
 	AttributeKeyReactionID           = "reaction_id"

--- a/x/relationships/keeper/msg_server.go
+++ b/x/relationships/keeper/msg_server.go
@@ -48,12 +48,6 @@ func (k msgServer) CreateRelationship(goCtx context.Context, msg *types.MsgCreat
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeRelationshipCreated,
 			sdk.NewAttribute(types.AttributeRelationshipCreator, msg.Signer),
 			sdk.NewAttribute(types.AttributeRelationshipCounterparty, msg.Counterparty),
@@ -82,12 +76,6 @@ func (k msgServer) DeleteRelationship(goCtx context.Context, msg *types.MsgDelet
 	k.Keeper.DeleteRelationship(ctx, msg.Signer, msg.Counterparty, msg.SubspaceID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeRelationshipDeleted,
 			sdk.NewAttribute(types.AttributeRelationshipCreator, msg.Signer),
@@ -118,12 +106,6 @@ func (k msgServer) BlockUser(goCtx context.Context, msg *types.MsgBlockUser) (*t
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Blocker),
-		),
-		sdk.NewEvent(
 			types.EventTypeBlockUser,
 			sdk.NewAttribute(types.AttributeKeyUserBlockBlocker, msg.Blocker),
 			sdk.NewAttribute(types.AttributeKeyUserBlockBlocked, msg.Blocked),
@@ -152,12 +134,6 @@ func (k msgServer) UnblockUser(goCtx context.Context, msg *types.MsgUnblockUser)
 	k.DeleteUserBlock(ctx, msg.Blocker, msg.Blocked, msg.SubspaceID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Blocker),
-		),
 		sdk.NewEvent(
 			types.EventTypeUnblockUser,
 			sdk.NewAttribute(types.AttributeKeyUserBlockBlocker, msg.Blocker),

--- a/x/relationships/keeper/msg_server_test.go
+++ b/x/relationships/keeper/msg_server_test.go
@@ -82,12 +82,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateRelationship() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateRelationship{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRelationshipCreated,
 					sdk.NewAttribute(types.AttributeRelationshipCreator, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
 					sdk.NewAttribute(types.AttributeRelationshipCounterparty, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
@@ -186,12 +180,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteRelationship() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeleteRelationship{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
 				sdk.NewEvent(
 					types.EventTypeRelationshipDeleted,
 					sdk.NewAttribute(types.AttributeRelationshipCreator, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
@@ -295,12 +283,6 @@ func (suite *KeeperTestSuite) TestMsgServer_BlockUser() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgBlockUser{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
-				sdk.NewEvent(
 					types.EventTypeBlockUser,
 					sdk.NewAttribute(types.AttributeKeyUserBlockBlocker, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
 					sdk.NewAttribute(types.AttributeKeyUserBlockBlocked, "cosmos1cjf97gpzwmaf30pzvaargfgr884mpp5ak8f7ns"),
@@ -400,12 +382,6 @@ func (suite *KeeperTestSuite) TestMsgServer_UnblockUser() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUnblockUser{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
-				),
 				sdk.NewEvent(
 					types.EventTypeUnblockUser,
 					sdk.NewAttribute(types.AttributeKeyUserBlockBlocker, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),

--- a/x/relationships/types/events.go
+++ b/x/relationships/types/events.go
@@ -8,7 +8,6 @@ const (
 	EventTypeBlockUser           = "block_user"
 	EventTypeUnblockUser         = "unblock_user"
 
-	AttributeValueCategory            = ModuleName
 	AttributeRelationshipCreator      = "creator"
 	AttributeRelationshipCounterparty = "counterparty"
 	AttributeKeyUserBlockBlocker      = "blocker"

--- a/x/reports/keeper/msg_server.go
+++ b/x/reports/keeper/msg_server.go
@@ -111,12 +111,6 @@ func (k msgServer) CreateReport(goCtx context.Context, msg *types.MsgCreateRepor
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Reporter),
-		),
-		sdk.NewEvent(
 			types.EventTypeCreateReport,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyReportID, fmt.Sprintf("%d", report.ID)),
@@ -158,12 +152,6 @@ func (k msgServer) DeleteReport(goCtx context.Context, msg *types.MsgDeleteRepor
 	k.Keeper.DeleteReport(ctx, msg.SubspaceID, msg.ReportID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeDeleteReport,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -215,12 +203,6 @@ func (k msgServer) SupportStandardReason(goCtx context.Context, msg *types.MsgSu
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeSupportStandardReason,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyStandardReasonID, fmt.Sprintf("%d", msg.StandardReasonID)),
@@ -268,12 +250,6 @@ func (k msgServer) AddReason(goCtx context.Context, msg *types.MsgAddReason) (*t
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeAddReason,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyReasonID, fmt.Sprintf("%d", reason.ID)),
@@ -309,12 +285,6 @@ func (k msgServer) RemoveReason(goCtx context.Context, msg *types.MsgRemoveReaso
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeRemoveReason,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyReasonID, fmt.Sprintf("%d", msg.ReasonID)),
@@ -333,15 +303,6 @@ func (m msgServer) UpdateParams(goCtx context.Context, msg *types.MsgUpdateParam
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	m.SetParams(ctx, msg.Params)
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Authority),
-		),
-	})
 
 	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/reports/keeper/msg_server_test.go
+++ b/x/reports/keeper/msg_server_test.go
@@ -280,12 +280,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateReport() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateReport{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"),
-				),
-				sdk.NewEvent(
 					types.EventTypeCreateReport,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyReportID, "1"),
@@ -381,12 +375,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateReport() {
 				CreationDate: time.Date(2020, 1, 1, 12, 00, 00, 000, time.UTC),
 			},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateReport{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"),
-				),
 				sdk.NewEvent(
 					types.EventTypeCreateReport,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -603,12 +591,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteReport() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeleteReport{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"),
-				),
-				sdk.NewEvent(
 					types.EventTypeDeleteReport,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyReportID, "1"),
@@ -650,12 +632,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteReport() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeleteReport{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDeleteReport,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -821,12 +797,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SupportStandardReason() {
 				ReasonsID: 1,
 			},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSupportStandardReason{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"),
-				),
 				sdk.NewEvent(
 					types.EventTypeSupportStandardReason,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -1006,12 +976,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AddReason() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAddReason{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"),
-				),
-				sdk.NewEvent(
 					types.EventTypeAddReason,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyReasonID, "1"),
@@ -1151,12 +1115,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RemoveReason() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRemoveReason{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qycmg40ju50fx2mcc82qtkzuswjs3mj3mqekeh"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRemoveReason,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyReasonID, "1"),
@@ -1211,14 +1169,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateParams() {
 				authtypes.NewModuleAddress("gov").String(),
 			),
 			shouldErr: false,
-			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUpdateParams{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn"),
-				),
-			},
+			expEvents: sdk.Events{},
 			check: func(ctx sdk.Context) {
 				params := suite.k.GetParams(ctx)
 				suite.Require().Equal(types.DefaultParams(), params)

--- a/x/reports/types/events.go
+++ b/x/reports/types/events.go
@@ -11,7 +11,6 @@ const (
 	EventTypeAddReason             = "add_reason"
 	EventTypeRemoveReason          = "remove_reason"
 
-	AttributeValueCategory       = ModuleName
 	AttributeKeySubspaceID       = "subspace_id"
 	AttributeKeyReportID         = "report_id"
 	AttributeKeyReporter         = "reporter"

--- a/x/subspaces/keeper/msg_server.go
+++ b/x/subspaces/keeper/msg_server.go
@@ -51,12 +51,6 @@ func (k msgServer) CreateSubspace(goCtx context.Context, msg *types.MsgCreateSub
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, subspace.Creator),
-		),
-		sdk.NewEvent(
 			types.EventTypeCreateSubspace,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", subspaceID)),
 			sdk.NewAttribute(types.AttributeKeySubspaceName, subspace.Name),
@@ -102,12 +96,6 @@ func (k msgServer) EditSubspace(goCtx context.Context, msg *types.MsgEditSubspac
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeEditSubspace,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", updated.ID)),
 		),
@@ -139,12 +127,6 @@ func (k msgServer) DeleteSubspace(goCtx context.Context, msg *types.MsgDeleteSub
 	k.Keeper.DeleteSubspace(ctx, msg.SubspaceID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeDeleteSubspace,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -199,12 +181,6 @@ func (k msgServer) CreateSection(goCtx context.Context, msg *types.MsgCreateSect
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Creator),
-		),
-		sdk.NewEvent(
 			types.EventTypeCreateSection,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", section.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeySectionID, fmt.Sprintf("%d", section.ID)),
@@ -253,12 +229,6 @@ func (k msgServer) EditSection(goCtx context.Context, msg *types.MsgEditSection)
 	k.SaveSection(ctx, updated)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Editor),
-		),
 		sdk.NewEvent(
 			types.EventTypeEditSection,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", section.SubspaceID)),
@@ -316,12 +286,6 @@ func (k msgServer) MoveSection(goCtx context.Context, msg *types.MsgMoveSection)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeMoveSection,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeySectionID, fmt.Sprintf("%d", msg.SectionID)),
@@ -359,12 +323,6 @@ func (k msgServer) DeleteSection(goCtx context.Context, msg *types.MsgDeleteSect
 	k.Keeper.DeleteSection(ctx, msg.SubspaceID, msg.SectionID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeDeleteSection,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -442,12 +400,6 @@ func (k msgServer) CreateUserGroup(goCtx context.Context, msg *types.MsgCreateUs
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Creator),
-		),
-		sdk.NewEvent(
 			types.EventTypeCreateUserGroup,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyUserGroupID, fmt.Sprintf("%d", group.ID)),
@@ -493,12 +445,6 @@ func (k msgServer) EditUserGroup(goCtx context.Context, msg *types.MsgEditUserGr
 	k.SaveUserGroup(ctx, updated)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeEditUserGroup,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -555,12 +501,6 @@ func (k msgServer) MoveUserGroup(goCtx context.Context, msg *types.MsgMoveUserGr
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EvenTypeMoveUserGroup,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyUserGroupID, fmt.Sprintf("%d", msg.GroupID)),
@@ -612,12 +552,6 @@ func (k msgServer) SetUserGroupPermissions(goCtx context.Context, msg *types.Msg
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, signer.String()),
-		),
-		sdk.NewEvent(
 			types.EventTypeSetUserGroupPermissions,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyUserGroupID, fmt.Sprintf("%d", msg.GroupID)),
@@ -656,12 +590,6 @@ func (k msgServer) DeleteUserGroup(goCtx context.Context, msg *types.MsgDeleteUs
 	k.Keeper.DeleteUserGroup(ctx, msg.SubspaceID, msg.GroupID)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeDeleteUserGroup,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -712,12 +640,6 @@ func (k msgServer) AddUserToUserGroup(goCtx context.Context, msg *types.MsgAddUs
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
-		sdk.NewEvent(
 			types.EventTypeAddUserToGroup,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyUserGroupID, fmt.Sprintf("%d", msg.GroupID)),
@@ -762,12 +684,6 @@ func (k msgServer) RemoveUserFromUserGroup(goCtx context.Context, msg *types.Msg
 	k.RemoveUserFromGroup(ctx, msg.SubspaceID, msg.GroupID, msg.User)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Signer),
-		),
 		sdk.NewEvent(
 			types.EventTypeRemoveUserFromGroup,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
@@ -818,12 +734,6 @@ func (k msgServer) SetUserPermissions(goCtx context.Context, msg *types.MsgSetUs
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, signer.String()),
-		),
-		sdk.NewEvent(
 			types.EventTypeSetUserPermissions,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyUser, msg.User),
@@ -868,12 +778,6 @@ func (k msgServer) GrantTreasuryAuthorization(goCtx context.Context, msg *types.
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Granter),
-		),
-		sdk.NewEvent(
 			types.EventTypeGrantTreasuryAuthorization,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyGranter, msg.Granter),
@@ -912,12 +816,6 @@ func (k msgServer) RevokeTreasuryAuthorization(goCtx context.Context, msg *types
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Granter),
-		),
-		sdk.NewEvent(
 			types.EventTypeRevokeTreasuryAuthorization,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeKeyGranter, msg.Granter),
@@ -939,14 +837,7 @@ func (k msgServer) GrantAllowance(goCtx context.Context, msg *types.MsgGrantAllo
 		return nil, errors.Wrap(types.ErrPermissionDenied, "you cannot manage allowances in this subspace")
 	}
 
-	events := sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Granter),
-		),
-	}
+	events := sdk.Events{}
 
 	switch grantee := msg.Grantee.GetCachedValue().(type) {
 	case *types.UserGrantee:
@@ -1004,14 +895,7 @@ func (k msgServer) RevokeAllowance(goCtx context.Context, msg *types.MsgRevokeAl
 		return nil, errors.Wrap(types.ErrPermissionDenied, "you cannot manage allowances in this subspace")
 	}
 
-	events := sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Granter),
-		),
-	}
+	events := sdk.Events{}
 
 	switch grantee := msg.Grantee.GetCachedValue().(type) {
 	case *types.UserGrantee:
@@ -1071,12 +955,6 @@ func (k msgServer) UpdateSubspaceFeeTokens(goCtx context.Context, msg *types.Msg
 	k.SaveSubspace(ctx, updated)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Authority),
-		),
 		sdk.NewEvent(
 			types.EventTypeUpdateSubspaceFeeToken,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", updated.ID)),

--- a/x/subspaces/keeper/msg_server_test.go
+++ b/x/subspaces/keeper/msg_server_test.go
@@ -63,12 +63,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateSubspace() {
 			expResponse: &types.MsgCreateSubspaceResponse{SubspaceID: 1},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateSubspace{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-				),
-				sdk.NewEvent(
 					types.EventTypeCreateSubspace,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeySubspaceName, "Test subspace"),
@@ -117,12 +111,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateSubspace() {
 			shouldErr:   false,
 			expResponse: &types.MsgCreateSubspaceResponse{SubspaceID: 1},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateSubspace{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos18atyyv6zycryhvnhpr2mjxgusdcah6kdpkffq0"),
-				),
 				sdk.NewEvent(
 					types.EventTypeCreateSubspace,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -177,12 +165,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateSubspace() {
 			shouldErr:   false,
 			expResponse: &types.MsgCreateSubspaceResponse{SubspaceID: 2},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateSubspace{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1y4emx0mm4ncva9mnv9yvjrm7nrq3psvmwhk9ll"),
-				),
 				sdk.NewEvent(
 					types.EventTypeCreateSubspace,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "2"),
@@ -376,12 +358,6 @@ func (suite *KeeperTestSuite) TestMsgServer_EditSubspace() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgEditSubspace{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5"),
-				),
-				sdk.NewEvent(
 					types.EventTypeEditSubspace,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 				),
@@ -504,12 +480,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteSubspace() {
 			msg:       types.NewMsgDeleteSubspace(1, "cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5"),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeleteSubspace{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDeleteSubspace,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -742,12 +712,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateSection() {
 			expResponse: &types.MsgCreateSectionResponse{SectionID: 2},
 			expEvent: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateSection{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1wq7mruftxd03qrrf9f7xnnzyqda9rkq5sshnr4"),
-				),
-				sdk.NewEvent(
 					types.EventTypeCreateSection,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeySectionID, "2"),
@@ -947,12 +911,6 @@ func (suite *KeeperTestSuite) TestMsgServer_EditSection() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgEditSection{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1wq7mruftxd03qrrf9f7xnnzyqda9rkq5sshnr4"),
-				),
 				sdk.NewEvent(
 					types.EventTypeEditSection,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -1209,12 +1167,6 @@ func (suite *KeeperTestSuite) TestMsgServer_MoveSection() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgMoveSection{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1wq7mruftxd03qrrf9f7xnnzyqda9rkq5sshnr4"),
-				),
-				sdk.NewEvent(
 					types.EventTypeMoveSection,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeySectionID, "2"),
@@ -1361,12 +1313,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteSection() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeleteSection{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1wq7mruftxd03qrrf9f7xnnzyqda9rkq5sshnr4"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDeleteSection,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -1594,12 +1540,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateUserGroup() {
 			expResponse: &types.MsgCreateUserGroupResponse{GroupID: 2},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateUserGroup{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
-				sdk.NewEvent(
 					types.EventTypeCreateUserGroup,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyUserGroupID, "2"),
@@ -1796,12 +1736,6 @@ func (suite *KeeperTestSuite) TestMsgServer_EditUserGroup() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgEditUserGroup{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
 				sdk.NewEvent(
 					types.EventTypeEditUserGroup,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -2110,12 +2044,6 @@ func (suite *KeeperTestSuite) TestMsgServer_MoveUserGroup() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgMoveUserGroup{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
-				sdk.NewEvent(
 					types.EvenTypeMoveUserGroup,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyUserGroupID, "1"),
@@ -2336,12 +2264,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SetUserGroupPermissions() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSetUserGroupPermissions{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1m0czrla04f7rp3zg7dsgc4kla54q7pc4xt00l5"),
-				),
-				sdk.NewEvent(
 					types.EventTypeSetUserGroupPermissions,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyUserGroupID, "1"),
@@ -2391,12 +2313,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SetUserGroupPermissions() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSetUserGroupPermissions{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
 				sdk.NewEvent(
 					types.EventTypeSetUserGroupPermissions,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -2542,12 +2458,6 @@ func (suite *KeeperTestSuite) TestMsgServer_DeleteUserGroup() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgDeleteUserGroup{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
 				sdk.NewEvent(
 					types.EventTypeDeleteUserGroup,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -2728,12 +2638,6 @@ func (suite *KeeperTestSuite) TestMsgServer_AddUserToGroup() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgAddUserToUserGroup{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
-				sdk.NewEvent(
 					types.EventTypeAddUserToGroup,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyUserGroupID, "1"),
@@ -2913,12 +2817,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RemoveUserFromGroup() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRemoveUserFromUserGroup{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRemoveUserFromGroup,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyUserGroupID, "1"),
@@ -3085,12 +2983,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SetUserPermissions() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSetUserPermissions{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos17ua98rre5j9ce7hfude0y5y3rh4gtqkygm8hru"),
-				),
-				sdk.NewEvent(
 					types.EventTypeSetUserPermissions,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyUser, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
@@ -3219,12 +3111,6 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateSubspaceFeeTokens() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUpdateSubspaceFeeTokens{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, authtypes.NewModuleAddress("gov").String()),
-				),
 				sdk.NewEvent(
 					types.EventTypeUpdateSubspaceFeeToken,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -3407,12 +3293,6 @@ func (suite *KeeperTestSuite) TestMsgServer_GrantTreasuryAuthorization() {
 			shouldErr:   false,
 			expResponse: &types.MsgGrantTreasuryAuthorizationResponse{},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgGrantTreasuryAuthorization{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1lv3e0l66rr68k5l74mnrv4j9kyny6cz27pvnez"),
-				),
 				sdk.NewEvent(
 					types.EventTypeGrantTreasuryAuthorization,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -3637,12 +3517,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RevokeTreasuryAuthorization() {
 			shouldErr:   false,
 			expResponse: &types.MsgRevokeTreasuryAuthorizationResponse{},
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRevokeTreasuryAuthorization{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1lv3e0l66rr68k5l74mnrv4j9kyny6cz27pvnez"),
-				),
 				sdk.NewEvent(
 					types.EventTypeRevokeTreasuryAuthorization,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -3881,12 +3755,6 @@ func (suite *KeeperTestSuite) TestMsgServer_GrantAllowance() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgGrantAllowance{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
-				sdk.NewEvent(
 					types.EventTypeGrantAllowance,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyGranter, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
@@ -3942,12 +3810,6 @@ func (suite *KeeperTestSuite) TestMsgServer_GrantAllowance() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgGrantAllowance{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
 				sdk.NewEvent(
 					types.EventTypeGrantAllowance,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
@@ -4115,12 +3977,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RevokeAllowance() {
 			shouldErr: false,
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRevokeAllowance{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
-				sdk.NewEvent(
 					types.EventTypeRevokeAllowance,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeKeyGranter, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
@@ -4165,12 +4021,6 @@ func (suite *KeeperTestSuite) TestMsgServer_RevokeAllowance() {
 			),
 			shouldErr: false,
 			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgRevokeAllowance{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1x5pjlvufs4znnhhkwe8v4tw3kz30f3lxgwza53"),
-				),
 				sdk.NewEvent(
 					types.EventTypeRevokeAllowance,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),

--- a/x/subspaces/types/events.go
+++ b/x/subspaces/types/events.go
@@ -23,7 +23,6 @@ const (
 	EventTypeRevokeAllowance             = "revoke_allowance"
 	EventTypeUpdateSubspaceFeeToken      = "update_subspace_fee_token"
 
-	AttributeValueCategory      = ModuleName
 	AttributeKeySubspaceID      = "subspace_id"
 	AttributeKeySubspaceName    = "subspace_name"
 	AttributeKeySubspaceCreator = "subspace_creator"

--- a/x/tokenfactory/keeper/msg_server.go
+++ b/x/tokenfactory/keeper/msg_server.go
@@ -44,12 +44,6 @@ func (k msgServer) CreateDenom(goCtx context.Context, msg *types.MsgCreateDenom)
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-		sdk.NewEvent(
 			types.EventTypeCreateDenom,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeCreator, msg.Sender),
@@ -84,12 +78,6 @@ func (k msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.MsgMi
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-		sdk.NewEvent(
 			types.EventTypeMint,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeMintToAddress, subspace.Treasury),
@@ -122,12 +110,6 @@ func (k msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.MsgBu
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-		sdk.NewEvent(
 			types.EventTypeBurn,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeBurnFromAddress, subspace.Treasury),
@@ -157,12 +139,6 @@ func (k msgServer) SetDenomMetadata(goCtx context.Context, msg *types.MsgSetDeno
 
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-		sdk.NewEvent(
 			types.ActionSetDenomMetadata,
 			sdk.NewAttribute(types.AttributeKeySubspaceID, fmt.Sprintf("%d", msg.SubspaceID)),
 			sdk.NewAttribute(types.AttributeDenom, msg.Metadata.Base),
@@ -181,15 +157,6 @@ func (k msgServer) UpdateParams(goCtx context.Context, msg *types.MsgUpdateParam
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	k.SetParams(ctx, msg.Params)
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(msg)),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Authority),
-		),
-	})
 
 	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/tokenfactory/keeper/msg_server_test.go
+++ b/x/tokenfactory/keeper/msg_server_test.go
@@ -164,12 +164,6 @@ func (suite *KeeperTestSuite) TestMsgServer_CreateDenom() {
 			},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgCreateDenom{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-				),
-				sdk.NewEvent(
 					types.EventTypeCreateDenom,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeCreator, "cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
@@ -439,12 +433,6 @@ func (suite *KeeperTestSuite) TestMsgServer_Mint() {
 			expResponse: &types.MsgMintResponse{},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgMint{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-				),
-				sdk.NewEvent(
 					types.EventTypeMint,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeMintToAddress, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
@@ -705,12 +693,6 @@ func (suite *KeeperTestSuite) TestMsgServer_Burn() {
 			expResponse: &types.MsgBurnResponse{},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgBurn{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-				),
-				sdk.NewEvent(
 					types.EventTypeBurn,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeBurnFromAddress, "cosmos1y54exmx84cqtasvjnskf9f63djuuj68p7hqf47"),
@@ -859,12 +841,6 @@ func (suite *KeeperTestSuite) TestMsgServer_SetDenomMetadata() {
 			expResponse: &types.MsgSetDenomMetadataResponse{},
 			expEvents: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgSetDenomMetadata{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1qzskhrcjnkdz2ln4yeafzsdwht8ch08j4wed69"),
-				),
-				sdk.NewEvent(
 					types.EventTypeSetDenomMetadata,
 					sdk.NewAttribute(types.AttributeKeySubspaceID, "1"),
 					sdk.NewAttribute(types.AttributeDenom, metadata.Base),
@@ -928,14 +904,7 @@ func (suite *KeeperTestSuite) TestMsgServer_UpdateParams() {
 					suite.k.GetParams(ctx),
 				)
 			},
-			expEvents: sdk.Events{
-				sdk.NewEvent(
-					sdk.EventTypeMessage,
-					sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-					sdk.NewAttribute(sdk.AttributeKeyAction, sdk.MsgTypeURL(&types.MsgUpdateParams{})),
-					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn"),
-				),
-			},
+			expEvents: sdk.Events{},
 		},
 	}
 	for _, tc := range testCases {

--- a/x/tokenfactory/types/events.go
+++ b/x/tokenfactory/types/events.go
@@ -9,7 +9,6 @@ const (
 	EventTypeBurn             = "tf_burn"
 	EventTypeSetDenomMetadata = "set_denom_metadata"
 
-	AttributeValueCategory   = ModuleName
 	AttributeKeySubspaceID   = "subspace_id"
 	AttributeAmount          = "amount"
 	AttributeCreator         = "creator"


### PR DESCRIPTION
## Description

Currently, the `sdk.MessageEventType` is emitted twice in Desmos, it is because that cosmos-sdk already handles the default message type event.
As we can see, [the example transaction](https://testnet.bigdipper.live/desmos/transactions/F2340B9AFB6FF097085820B9F784251777FE43A700F0185E9542EF1AED914679) has two message type event:
```json
[
    {
        "events": [
            {
                "type": "message",
                "attributes": [
                    {
                        "key": "action",
                        "value": "/desmos.posts.v3.MsgCreatePost"
                    },
                    {
                        "key": "sender",
                        "value": "desmos1q35n50xnlj7lapfkzzcq5rvypcvhure0rr945u"
                    }
                ]
            },
            {
                "type": "message",
                "attributes": [
                    {
                        "key": "module",
                        "value": "posts"
                    },
                    {
                        "key": "action",
                        "value": "/desmos.posts.v3.MsgCreatePost"
                    },
                    {
                        "key": "sender",
                        "value": "desmos1q35n50xnlj7lapfkzzcq5rvypcvhure0rr945u"
                    }
                ]
            },
         ...skip
]
``` 

To fix it, we can safely remove the `sdk.MessageEventType` event inside Desmos modules.
References:
https://docs.cosmos.network/v0.47/learn/advanced/events#default-events
https://github.com/cosmos/cosmos-sdk/blob/v0.47.5/baseapp/baseapp.go#L848



<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://docs.cosmos.network/v0.44/building-modules/intro.html)
- [ ] included the necessary unit and integration [tests](https://github.com/desmos-labs/desmos/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)